### PR TITLE
Update README again to properly reference build status svg image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Mojave Sun codebase
 
-[![Build Status](https://travis-ci.com/RobustTeam/tg-ashcloud.svg?branch=master)](https://travis-ci.com/github/Mojave-Sun/mojave-sun)
+[![Build Status](https://travis-ci.com/Mojave-Sun/mojave-sun.svg?branch=master)](https://travis-ci.com/github/Mojave-Sun/mojave-sun)
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/Mojave-Sun/mojave-sun.svg)](http://isitmaintained.com/project/Mojave-Sun/mojave-sun "Percentage of issues still open")
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/Mojave-Sun/mojave-sun.svg)](http://isitmaintained.com/project/Mojave-Sun/mojave-sun "Average time to resolve an issue")
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.com/Mojave-Sun/mojave-sun.svg?branch=master)](https://travis-ci.com/github/Mojave-Sun/mojave-sun)
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/Mojave-Sun/mojave-sun.svg)](http://isitmaintained.com/project/Mojave-Sun/mojave-sun "Percentage of issues still open")
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/Mojave-Sun/mojave-sun.svg)](http://isitmaintained.com/project/Mojave-Sun/mojave-sun "Average time to resolve an issue")
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 [![forthebadge](https://forthebadge.com/images/badges/built-with-resentment.svg)](https://forthebadge.com) [![forthebadge](https://forthebadge.com/images/badges/contains-technical-debt.svg)](https://user-images.githubusercontent.com/8171642/50290880-ffef5500-043a-11e9-8270-a2e5b697c86c.png) [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
 


### PR DESCRIPTION
<!-- HEY LISTEN!!! -->

<!-- WHEN MAKING A NEW PR TO THIS GIT, BE ABSOLUTELY SURE THE BASE REPO YOU'RE COMMITING TO ISN'T tgstation/tgstation IT SHOULD BE RobustTeam/tg-ashcloud -->

<!-- In edition changelogs won't be ultilized due to the way pulling from upstream tg will heavily filter out the old ones; instead change the changelog on the discord if we ever make one -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
README reference to the travis build status was incorrect.  Also adds a badge for the license.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Without the change, the build status icon is utterly useless.
