### PR TITLE
Disables atmos and hotspots

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -3,6 +3,15 @@
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
 
+/*
+	Comment this to enable atmos
+	This stops the atmos system from initing and running
+	It also prevents gasmixtures from being added to/removed from
+	If a removal is attempted, it instead copys as expected
+	It also immediatly qdels hotspots, so no fire allowrd
+*/
+#define HALT_ATMOS
+
 // Comment this out if you are debugging problems that might be obscured by custom error handling in world/Error
 #ifdef DEBUG
 #define USE_CUSTOM_ERROR_HANDLER

--- a/code/controllers/subsystem/adjacent_air.dm
+++ b/code/controllers/subsystem/adjacent_air.dm
@@ -5,6 +5,9 @@ SUBSYSTEM_DEF(adjacent_air)
 	wait = 10
 	priority = FIRE_PRIORITY_ATMOS_ADJACENCY
 	var/list/queue = list()
+#ifdef HALT_ATMOS
+	can_fire = FALSE
+#endif
 
 /datum/controller/subsystem/adjacent_air/stat_entry()
 #ifdef TESTING
@@ -13,10 +16,12 @@ SUBSYSTEM_DEF(adjacent_air)
 	..("P:[length(queue)]")
 #endif
 
+#ifndef HALT_ATMOS
 /datum/controller/subsystem/adjacent_air/Initialize()
 	while(length(queue))
 		fire(mc_check = FALSE)
 	return ..()
+#endif
 
 /datum/controller/subsystem/adjacent_air/fire(resumed = FALSE, mc_check = TRUE)
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -37,7 +37,11 @@ SUBSYSTEM_DEF(air)
 
 	var/map_loading = TRUE
 	var/list/queued_for_activation
+#ifdef HALT_ATMOS
+	can_fire = FALSE
+#endif
 
+#ifndef HALT_ATMOS
 /datum/controller/subsystem/air/stat_entry(msg)
 	msg += "C:{"
 	msg += "AT:[round(cost_turfs,1)]|"
@@ -57,8 +61,9 @@ SUBSYSTEM_DEF(air)
 	msg += "AS:[active_super_conductivity.len]|"
 	msg += "AT/MS:[round((cost ? active_turfs.len/cost : 0),0.1)]"
 	..(msg)
+#endif
 
-
+#ifndef HALT_ATMOS
 /datum/controller/subsystem/air/Initialize(timeofday)
 	map_loading = FALSE
 	setup_allturfs()
@@ -66,6 +71,7 @@ SUBSYSTEM_DEF(air)
 	setup_pipenets()
 	gas_reactions = init_gas_reactions()
 	return ..()
+#endif
 
 
 /datum/controller/subsystem/air/fire(resumed = 0)

--- a/code/game/objects/items/chrono_eraser.dm
+++ b/code/game/objects/items/chrono_eraser.dm
@@ -254,7 +254,7 @@
 		return BULLET_ACT_HIT
 
 /obj/structure/chrono_field/assume_air()
-	return 0
+	return FALSE
 
 /obj/structure/chrono_field/return_air() //we always have nominal air and temperature
 	var/datum/gas_mixture/GM = new

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -61,6 +61,7 @@
 
 /obj/effect/hotspot/Initialize(mapload, starting_volume, starting_temperature)
 	. = ..()
+#ifndef HALT_ATMOS
 	SSair.hotspots += src
 	if(!isnull(starting_volume))
 		volume = starting_volume
@@ -69,6 +70,9 @@
 	perform_exposure()
 	setDir(pick(GLOB.cardinals))
 	air_update_turf()
+#else
+	qdel(src)
+#endif
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/open/location = loc

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 #endif
 	return removed
 
-	///Removes a amount of a specific gas from the gas_mixture.
+	///Removes an amount of a specific gas from the gas_mixture.
 	///Returns: gas_mixture with the gas removed
 /datum/gas_mixture/proc/remove_specific(gas_id, amount)
 	var/list/cached_gases = gases

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -136,9 +136,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 	///Merges all air from giver into self. Deletes giver. Returns: 1 if we are mutable, 0 otherwise
 /datum/gas_mixture/proc/merge(datum/gas_mixture/giver)
+#ifndef HALT_ATMOS
 	if(!giver)
 		return 0
-
 	//heat transfer
 	if(abs(temperature - giver.temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 		var/self_heat_capacity = heat_capacity()
@@ -153,7 +153,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/giver_id in giver_gases)
 		ASSERT_GAS(giver_id, src)
 		cached_gases[giver_id][MOLES] += giver_gases[giver_id][MOLES]
-
+#endif
 	return 1
 
 	///Proportionally removes amount of gas from the gas_mixture.
@@ -172,9 +172,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/id in cached_gases)
 		ADD_GAS(id, removed.gases)
 		removed_gases[id][MOLES] = QUANTIZE((cached_gases[id][MOLES] / sum) * amount)
+#ifndef HALT_ATMOS //This behaves like a proportional copy() if we don't want atmos to change shit
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
 	garbage_collect()
-
+#endif
 	return removed
 
 	///Proportionally removes amount of gas from the gas_mixture.
@@ -192,13 +193,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	for(var/id in cached_gases)
 		ADD_GAS(id, removed.gases)
 		removed_gases[id][MOLES] = QUANTIZE(cached_gases[id][MOLES] * ratio)
+#ifndef HALT_ATMOS //This behaves like a proportional copy() if we don't want atmos to change shit
 		cached_gases[id][MOLES] -= removed_gases[id][MOLES]
-
 	garbage_collect()
-
+#endif
 	return removed
 
-	///Removes an amount of a specific gas from the gas_mixture.
+	///Removes a amount of a specific gas from the gas_mixture.
 	///Returns: gas_mixture with the gas removed
 /datum/gas_mixture/proc/remove_specific(gas_id, amount)
 	var/list/cached_gases = gases
@@ -210,14 +211,16 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	removed.temperature = temperature
 	ADD_GAS(gas_id, removed.gases)
 	removed_gases[gas_id][MOLES] = amount
+#ifndef HALT_ATMOS //This behaves like a single target copy() if we don't want atmos to change shit
 	cached_gases[gas_id][MOLES] -= amount
-
 	garbage_collect(list(gas_id))
+#endif
 	return removed
 
 	///Distributes the contents of two mixes equally between themselves
 	//Returns: bool indicating whether gases moved between the two mixes
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
+#ifndef HALT_ATMOS
 	. = FALSE
 	if(abs(return_temperature() - other.return_temperature()) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
 		. = TRUE
@@ -239,7 +242,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)
 			other.gases[gas_id][MOLES] = total_moles * (other.volume/total_volume)
-
+#endif
 
 	///Creates new, identical gas mixture
 	///Returns: duplicate gas mixture


### PR DESCRIPTION
<!-- HEY LISTEN!!! -->

<!-- WHEN MAKING A NEW PR TO THIS GIT, BE ABSOLUTELY SURE THE BASE REPO YOU'RE COMMITING TO ISN'T tgstation/tgstation IT SHOULD BE RobustTeam/tg-ashcloud -->

<!-- In edition changelogs won't be ultilized due to the way pulling from upstream tg will heavily filter out the old ones; instead change the changelog on the discord if we ever make one -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a preprocessor toggle to disable atmos and hotspots, while maintaining the integrity of things like breathcode.
Basically anything that removes gas now copies, and anything that merges gas does nothing.

I also disabled the 2 atmos subsystems, **NOTE: Pipes will not hook together, do not map with them if this is merged**
and made hotspots instantly qdel so there's no funny business with molotovs.

I need to do a pass for things that change temp, but I think this about does it.  
Yell at me if I missed something. 

## Why It's Good For The Game

She was so beautiful, but she had to die.