### PR TITLE
Gravity and multiz fixes

### DIFF
--- a/_maps/mammoth.json
+++ b/_maps/mammoth.json
@@ -5,5 +5,24 @@
 	"shuttles": {
 	    "cargo": "cargo_delta"
     },
-	"traits": [{"Up" : 1, "Linkage" : "Cross", "Baseturf" : "/turf/open/floor/plating/ground/mountain"}, {"Up" : 1, "Down" : -1, "Baseturf" : "/turf/open/transparent/openspace", "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/transparent/openspace", "Linkage" : "Cross"}]
-	}
+	"traits": [
+        {
+            "Up" : 1, 
+            "Linkage" : "Cross",
+            "Gravity" : true
+        }, 
+        {
+            "Up" : 1, 
+            "Down" : -1, 
+            "Baseturf" : "/turf/open/transparent/openspace", 
+            "Linkage" : "Cross",
+            "Gravity" : true
+        }, 
+        {
+            "Down" : -1,
+            "Baseturf" : "/turf/open/transparent/openspace", 
+            "Linkage" : "Cross",
+            "Gravity" : true
+        }
+    ]
+}

--- a/_maps/mammoth.json
+++ b/_maps/mammoth.json
@@ -9,6 +9,7 @@
         {
             "Up" : 1, 
             "Linkage" : "Cross",
+            "Baseturf" : "/turf/open/floor/plating/ground/mountain",
             "Gravity" : true
         }, 
         {

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -557,10 +557,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
-"aem" = (
-/obj/machinery/gravity_generator/main/station/admin,
-/turf/open/floor/plating,
-/area/f13/klamat)
 "aen" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -7002,9 +6998,6 @@
 /obj/item/stack/sheet/mineral/uranium,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
-"aTb" = (
-/turf/open/floor/plating,
-/area/f13/tcoms)
 "aTc" = (
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating/ground/mountain,
@@ -7194,9 +7187,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/f13/klamat)
-"aTW" = (
-/turf/closed/wall/r_wall/f13/metal,
-/area/f13/tcoms)
 "aTY" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/ground/dirt,
@@ -7684,10 +7674,6 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/klamat)
-"aWt" = (
-/obj/machinery/gravity_generator/main/station/admin,
-/turf/open/floor/plating,
-/area/f13/tcoms)
 "aWv" = (
 /obj/machinery/shower{
 	dir = 8
@@ -12795,11 +12781,11 @@ afK
 "}
 (2,1,1) = {"
 afK
-aTW
-aTW
-aTW
-aTW
-afK
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -13052,11 +13038,11 @@ afK
 "}
 (3,1,1) = {"
 afK
-aTW
-aTb
-aWt
-aTW
-afK
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -13309,11 +13295,11 @@ afK
 "}
 (4,1,1) = {"
 afK
-aTW
-aTb
-aTb
-aTW
-afK
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -13566,11 +13552,11 @@ afK
 "}
 (5,1,1) = {"
 afK
-aTW
-aTW
-aTW
-aTW
-afK
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -13823,11 +13809,11 @@ afK
 "}
 (6,1,1) = {"
 afK
-afK
-afK
-afK
-afK
-afK
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -78590,7 +78576,7 @@ aiz
 afK
 aye
 abL
-aem
+aNR
 aye
 afK
 aae
@@ -143867,11 +143853,11 @@ aab
 "}
 (2,1,3) = {"
 afM
-aTW
-aTW
-aTW
-aTW
-afN
+aae
+aae
+aae
+aae
+aae
 afN
 afN
 afN
@@ -144124,11 +144110,11 @@ aab
 "}
 (3,1,3) = {"
 afM
-aTW
-aTb
-aWt
-aTW
-afN
+aae
+aae
+aae
+aae
+aae
 afN
 afN
 afN
@@ -144381,12 +144367,12 @@ aab
 "}
 (4,1,3) = {"
 afM
-aTW
-aTb
-aTb
-aTW
-afN
-afN
+aae
+aae
+aae
+aae
+aae
+aae
 afN
 afN
 afN
@@ -144638,11 +144624,11 @@ aab
 "}
 (5,1,3) = {"
 afM
-aTW
-aTW
-aTW
-aTW
-afN
+aae
+aae
+aae
+aae
+aae
 afN
 afN
 afN

--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -231,7 +231,7 @@
 /area/f13/sunny_dale)
 "abL" = (
 /obj/machinery/power/smes/magical,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/f13/red/_full/rusty,
 /area/f13/klamat)
 "abN" = (
 /obj/structure/sink{
@@ -501,7 +501,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/f13/red/_full/rusty,
 /area/f13/klamat)
 "adU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -557,6 +557,9 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
+"aem" = (
+/turf/open/floor/plasteel/f13/red/_full/rusty,
+/area/f13/klamat)
 "aen" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -1710,7 +1713,7 @@
 	dir = 4;
 	pixel_y = 15
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/f13/red/_full/rusty,
 /area/f13/klamat)
 "anQ" = (
 /obj/effect/decal/cleanable/glass,
@@ -78576,7 +78579,7 @@ aiz
 afK
 aye
 abL
-aNR
+aem
 aye
 afK
 aae

--- a/fallout/turfs/minerals.dm
+++ b/fallout/turfs/minerals.dm
@@ -13,7 +13,7 @@
 
 /turf/closed/mineral/random/f13/Initialize()
 	. = ..()
-	underlays += mutable_appearance('fallout/icons/turf/mining.dmi', "rockfloor1", TURF_LAYER, FLOOR_PLANE)
+	underlays += mutable_appearance('fallout/icons/turf/mining.dmi', "rockfloor1", TURF_LAYER)
 	pixel_x = 4
 	pixel_y = 4
 
@@ -28,4 +28,4 @@
 
 /turf/closed/indestructible/rock/f13/Initialize()
 	. = ..()
-	underlays += mutable_appearance('fallout/icons/turf/mining.dmi', "rockfloor1", TURF_LAYER, FLOOR_PLANE)
+	underlays += mutable_appearance('fallout/icons/turf/mining.dmi', "rockfloor1", TURF_LAYER)


### PR DESCRIPTION
<!-- HEY LISTEN!!! -->

<!-- Changelogs will not be used for now.  We will likely require changelogs when we launch. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Gravity generators are no more thanks to the map json having traits for setting gravity.

Removed the plane shifting of the mineral wall underlay.   Apparently the openspace turfs above would grab that underlay and then place it over everything else (the wall included).  Could refactor, but undersized turfs are proving to be a huge pain.  Will likely replace the sprite with something more functional soon.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Less invulnerable machinery needed in corners of the map.  Multi-z transitions sprites are now working properly.
