### PR TITLE
Fix security officer job related runtime.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -255,7 +255,8 @@ SUBSYSTEM_DEF(job)
 		return validate_required_jobs(required_jobs)
 
 	//Scale number of open security officer slots to population
-	setup_officer_positions()
+	//FALLOUT 13: This proc just causes runtimes since we don't use the sec officer job, so I'm commenting it out.
+	//setup_officer_positions()
 
 	//Jobs will have fewer access permissions if the number of players exceeds the threshold defined in game_options.txt
 	var/mat = CONFIG_GET(number/minimal_access_threshold)


### PR DESCRIPTION
## About The Pull Request

`/datum/controller/subsystem/job/proc/setup_officer_positions()` was causing a runtime, this fixes that by commenting out the proc call (which only occurs once in one place) since we don't need it anyway.

## Why It's Good For The Game

We should start slowly chipping away at our bootup runtimes.