### PR TITLE
Fix roofsetters.

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -429,6 +429,7 @@
 /area/f13/underground/cave)
 "afN" = (
 /obj/structure/safe,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "afP" = (
@@ -605,12 +606,12 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "aiv" = (
 /obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plating,
 /area/f13/klamat)
 "aiz" = (
@@ -667,7 +668,7 @@
 /turf/open/floor/plasteel/f13/green/_rusty,
 /area/f13/sunny_dale)
 "aja" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "ajb" = (
@@ -730,7 +731,7 @@
 /area/f13/klamat)
 "akd" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "ake" = (
@@ -779,7 +780,7 @@
 "akM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/random,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "akO" = (
@@ -926,7 +927,7 @@
 /obj/machinery/light/dim{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "amB" = (
@@ -1142,7 +1143,7 @@
 /turf/open/floor/carpet,
 /area/f13/klamat)
 "aqC" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -1167,7 +1168,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "aqW" = (
@@ -1190,7 +1191,7 @@
 "arp" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/stained,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "arq" = (
@@ -1240,7 +1241,7 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "atk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "atn" = (
@@ -1301,7 +1302,7 @@
 /area/f13/underground/bos)
 "auF" = (
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "auI" = (
@@ -1728,7 +1729,7 @@
 /area/f13/underground/bos)
 "aBx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -1820,7 +1821,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "aDz" = (
@@ -2184,17 +2185,17 @@
 	},
 /area/f13/sunny_dale)
 "aJG" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/chair/comfy/f13/ergo{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aJQ" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "aJT" = (
@@ -2374,7 +2375,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "aLI" = (
@@ -2469,10 +2470,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
-"aMs" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/_rusty,
-/area/f13/underground/bos)
 "aMw" = (
 /obj/structure/stairs/east{
 	dir = 1
@@ -2497,7 +2494,7 @@
 /area/f13/underground/bos)
 "aMz" = (
 /obj/structure/filingcabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aMB" = (
@@ -2544,7 +2541,7 @@
 /area/f13/sunny_dale)
 "aNd" = (
 /obj/structure/table/wood/fancy/black,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "aNg" = (
@@ -2565,12 +2562,12 @@
 /area/f13/klamat)
 "aNj" = (
 /obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/underground/bos)
 "aNm" = (
 /obj/structure/guncase,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aNn" = (
@@ -2630,7 +2627,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aNO" = (
@@ -2640,7 +2637,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aNP" = (
@@ -2662,19 +2659,19 @@
 /obj/structure/mirror{
 	pixel_x = -32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aOc" = (
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aOe" = (
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aOj" = (
@@ -2689,7 +2686,7 @@
 /area/f13/klamat)
 "aOm" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aOu" = (
@@ -2697,7 +2694,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aOw" = (
@@ -2720,7 +2717,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aOJ" = (
@@ -2738,7 +2735,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aOW" = (
@@ -2757,7 +2754,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "aPh" = (
@@ -2769,7 +2766,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "aPm" = (
@@ -2792,7 +2789,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aPu" = (
@@ -2926,7 +2923,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aQu" = (
@@ -2967,7 +2964,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aQR" = (
@@ -2980,12 +2977,12 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "aQV" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/dresser/f13/orange/pristine,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "aQY" = (
@@ -3011,24 +3008,24 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "aRj" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "aRk" = (
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "aRm" = (
 /obj/structure/table/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/underground/bos)
 "aRn" = (
@@ -3042,7 +3039,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full/rusty,
 /area/f13/underground/bos)
 "aRw" = (
@@ -3052,7 +3049,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aRz" = (
@@ -3106,14 +3103,14 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full/dirty,
 /area/f13/underground/bos)
 "aSd" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full/dirty,
 /area/f13/underground/bos)
 "aSe" = (
@@ -3121,7 +3118,7 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aSh" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /obj/item/shard,
 /turf/open/floor/wood/f13/broken,
@@ -3158,7 +3155,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aSH" = (
@@ -3166,7 +3163,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "aSJ" = (
@@ -3178,12 +3175,12 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full/dirty,
 /area/f13/underground/bos)
 "aSP" = (
 /obj/structure/toilet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aSQ" = (
@@ -3192,25 +3189,25 @@
 /area/f13/underground/bos)
 "aSZ" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "aTb" = (
 /obj/structure/guncase,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "aTc" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/wood,
 /area/f13/sunny_dale)
 "aTk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "aTm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "aTq" = (
@@ -3218,13 +3215,13 @@
 /area/f13/underground/bos)
 "aTr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/wood,
 /area/f13/sunny_dale)
 "aTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "aTw" = (
@@ -3233,11 +3230,11 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "aTy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "aTA" = (
@@ -3246,7 +3243,7 @@
 /area/f13/klamat)
 "aTC" = (
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "aTI" = (
@@ -3282,7 +3279,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "aTR" = (
@@ -3695,7 +3692,7 @@
 /area/f13/sunny_dale)
 "aYv" = (
 /obj/structure/table/low_wall/reinforced/metal/rust,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/powerplant)
 "aYw" = (
@@ -3826,8 +3823,8 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "aZN" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/metal,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "aZP" = (
@@ -3864,8 +3861,8 @@
 /area/f13/sunny_dale)
 "bbv" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/stained,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "bbD" = (
@@ -3878,7 +3875,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/underground/bos)
 "bcA" = (
@@ -3889,7 +3886,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "bdF" = (
@@ -3909,7 +3906,7 @@
 /turf/open/floor/plasteel/f13/misc/rarewhite/rarewhitechess,
 /area/f13/klamat)
 "bei" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/underground/bos)
 "bes" = (
@@ -3917,7 +3914,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "beu" = (
@@ -3950,7 +3947,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "bft" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/bedframe/wire,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -3958,7 +3955,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "biO" = (
@@ -3982,7 +3979,7 @@
 "bkn" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "bkS" = (
@@ -4023,7 +4020,7 @@
 "bnN" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "boy" = (
@@ -4044,7 +4041,7 @@
 	},
 /area/f13/sunny_dale)
 "bpg" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13,
@@ -4093,7 +4090,7 @@
 /area/f13/sunny_dale)
 "btY" = (
 /obj/machinery/door/airlock/wood/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "buk" = (
@@ -4101,12 +4098,12 @@
 /area/f13)
 "bul" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "buq" = (
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "bux" = (
@@ -4116,8 +4113,8 @@
 /turf/open/floor/wood/f13,
 /area/f13/ncr_main)
 "bvd" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -4155,7 +4152,7 @@
 /obj/item/restraints/legcuffs,
 /obj/item/restraints/legcuffs,
 /obj/item/restraints/legcuffs,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "byk" = (
@@ -4173,16 +4170,16 @@
 /turf/open/floor/wood/f13,
 /area/f13)
 "bzz" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/yellowed,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "bAu" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "bAL" = (
@@ -4195,12 +4192,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "bBL" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "bBQ" = (
@@ -4210,7 +4207,7 @@
 "bCh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/dirty,
 /turf/open/floor/carpet/orange,
@@ -4234,7 +4231,7 @@
 /area/f13/ncr_main)
 "bDF" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "bDU" = (
@@ -4242,12 +4239,12 @@
 /area/f13/sunny_dale)
 "bDX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left3,
 /area/f13/sunny_dale)
 "bEI" = (
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "bGj" = (
@@ -4276,7 +4273,7 @@
 "bJp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "bJI" = (
@@ -4293,7 +4290,7 @@
 /obj/structure/chair/f13/metal{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "bKT" = (
@@ -4307,7 +4304,7 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "bLA" = (
@@ -4318,7 +4315,7 @@
 /area/f13/sunny_dale)
 "bLK" = (
 /obj/machinery/vending/tool,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "bNg" = (
@@ -4362,7 +4359,7 @@
 /area/f13/sunny_dale)
 "bQl" = (
 /obj/structure/table/low_wall/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -4423,30 +4420,30 @@
 /area/f13)
 "bWS" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "bXd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "bYk" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/stale,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "bZq" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/filthy,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "bZr" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "bZv" = (
@@ -4455,7 +4452,7 @@
 /area/f13/sunny_dale)
 "bZw" = (
 /obj/structure/bookcase,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "caN" = (
@@ -4476,7 +4473,7 @@
 "caW" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/light/small/built,
 /turf/open/floor/carpet/royalblack,
@@ -4485,7 +4482,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "cdG" = (
@@ -4508,7 +4505,7 @@
 "ceT" = (
 /obj/structure/railing,
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "ceX" = (
@@ -4544,13 +4541,13 @@
 /area/f13/sunny_dale)
 "chS" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "cib" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/yellowed,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "cir" = (
@@ -4584,7 +4581,7 @@
 /area/f13/ncr_main)
 "ckY" = (
 /obj/structure/filingcabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "coJ" = (
@@ -4612,7 +4609,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "crx" = (
@@ -4641,14 +4638,14 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ctD" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "ctK" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/toggle/labcoat,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "cuc" = (
@@ -4731,7 +4728,7 @@
 /area/f13)
 "cDO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "cDT" = (
@@ -4759,7 +4756,7 @@
 /obj/structure/bed/f13/sleepingbag/green,
 /obj/effect/mob_spawn/human/skeleton,
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/gun/ballistic/automatic/pistol/fallout/m9mm/handmade,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -4767,7 +4764,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "cHI" = (
@@ -4790,12 +4787,12 @@
 "cKd" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/stale,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "cLi" = (
 /obj/structure/curtain/cloth,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "cLD" = (
@@ -4832,21 +4829,21 @@
 /obj/structure/table/low_wall/wood,
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/curtain/cloth/fancy,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "cNM" = (
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "cNQ" = (
 /obj/structure/table,
 /obj/item/storage/toolbox,
 /obj/item/storage/toolbox,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "cOf" = (
@@ -4864,8 +4861,8 @@
 /area/f13)
 "cQt" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/old,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "cQC" = (
@@ -4877,7 +4874,7 @@
 "cQG" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/old,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "cRa" = (
@@ -4918,7 +4915,7 @@
 /area/f13/sunny_dale)
 "cTA" = (
 /obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/underground/bos)
 "cTM" = (
@@ -4930,12 +4927,12 @@
 /area/f13/sunny_dale)
 "cUi" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "cVd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "cVo" = (
@@ -4943,7 +4940,7 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "cVO" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
@@ -5034,7 +5031,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dfm" = (
@@ -5047,14 +5044,14 @@
 /obj/structure/table,
 /obj/item/screwdriver,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dgr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "dgF" = (
@@ -5079,7 +5076,7 @@
 /area/f13/sunny_dale)
 "dis" = (
 /obj/structure/toilet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "diy" = (
@@ -5099,20 +5096,20 @@
 	pixel_x = 11
 	},
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "djG" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/microwave,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "djT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/low_wall/wood,
 /obj/structure/table/low_wall/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -5152,7 +5149,7 @@
 "dnV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dom" = (
@@ -5161,12 +5158,12 @@
 /area/f13/sunny_dale)
 "dpH" = (
 /obj/machinery/chem_master,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "dpI" = (
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "dpJ" = (
@@ -5188,7 +5185,7 @@
 /area/f13/sunny_dale)
 "dqy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "dre" = (
@@ -5247,7 +5244,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
@@ -5261,17 +5258,17 @@
 /turf/open/floor/plasteel/f13/blue/white/whitebluechess/whitebluechess2,
 /area/f13/sunny_dale)
 "dwX" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken1,
 /area/f13/sunny_dale)
 "dxk" = (
 /obj/machinery/washing_machine,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "dxq" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "dxz" = (
@@ -5285,12 +5282,12 @@
 /area/f13/sunny_dale)
 "dyA" = (
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "dyT" = (
 /obj/structure/curtain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "dAt" = (
@@ -5298,9 +5295,9 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dBo" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/dirty,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "dCi" = (
@@ -5313,14 +5310,14 @@
 /area/f13)
 "dCJ" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "dDc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/paper,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dDH" = (
@@ -5349,7 +5346,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "dKP" = (
@@ -5365,22 +5362,22 @@
 /obj/structure/chair/comfy/f13/armchair{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dMM" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/alt,
 /area/f13/sunny_dale)
 "dNj" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dPk" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken1,
 /area/f13/sunny_dale)
 "dRZ" = (
@@ -5405,7 +5402,7 @@
 /turf/open/floor/plating/ground/road/sidewalk,
 /area/f13)
 "dTk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -5424,7 +5421,7 @@
 /area/f13/sunny_dale)
 "dUg" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "dUs" = (
@@ -5434,14 +5431,14 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dUJ" = (
 /obj/structure/railing,
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/item/binoculars,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "dVN" = (
@@ -5454,7 +5451,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "dWQ" = (
@@ -5479,7 +5476,7 @@
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/gloves/boxing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "dXV" = (
@@ -5494,7 +5491,7 @@
 "dYO" = (
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/red,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "dZe" = (
@@ -5503,7 +5500,7 @@
 /area/f13/klamat)
 "dZw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken1,
 /area/f13/sunny_dale)
 "dZN" = (
@@ -5546,13 +5543,13 @@
 /area/f13/sunny_dale)
 "ebi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "ebw" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/stained,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "ecq" = (
@@ -5576,7 +5573,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "eem" = (
@@ -5590,8 +5587,8 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "efF" = (
@@ -5643,7 +5640,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eil" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/scrap,
 /area/f13/sunny_dale)
 "eiC" = (
@@ -5677,13 +5674,13 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
 /obj/effect/landmark/start/f13/corporal,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "emH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "ena" = (
@@ -5700,7 +5697,7 @@
 "enJ" = (
 /obj/machinery/door/unpowered/wooddoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "enP" = (
@@ -5722,7 +5719,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "eoX" = (
@@ -5735,7 +5732,7 @@
 "epa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/crumpled,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eqy" = (
@@ -5768,7 +5765,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "etd" = (
@@ -5789,7 +5786,7 @@
 "euj" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "evO" = (
@@ -5799,8 +5796,8 @@
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/sunny_dale)
 "evQ" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -5825,7 +5822,7 @@
 "exL" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "exN" = (
@@ -5835,7 +5832,7 @@
 /obj/machinery/light/dim{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ezp" = (
@@ -5845,7 +5842,7 @@
 	},
 /area/f13/klamat)
 "ezO" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/right,
 /area/f13/sunny_dale)
 "ezP" = (
@@ -5853,14 +5850,14 @@
 /obj/structure/f13/tv{
 	name = "Radiation King Television"
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "ezW" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eAn" = (
@@ -5870,7 +5867,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
 	pixel_x = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eBs" = (
@@ -5894,13 +5891,13 @@
 "eCG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eDf" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/filthy,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "eDq" = (
@@ -5908,13 +5905,13 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "eDy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/stale,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "eDP" = (
@@ -5940,7 +5937,7 @@
 /turf/open/floor/plasteel/f13/blue/_dirty,
 /area/f13/sunny_dale)
 "eET" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/f13/metal/rust,
 /area/f13/underground/mountain)
 "eEW" = (
@@ -5952,7 +5949,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "eFv" = (
@@ -5962,19 +5959,19 @@
 /area/f13/sunny_dale)
 "eGf" = (
 /obj/structure/table/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/underground/bos)
 "eGx" = (
 /obj/structure/closet/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eHf" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "eHx" = (
@@ -5993,7 +5990,7 @@
 	dir = 8
 	},
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "eIT" = (
@@ -6002,22 +5999,22 @@
 /area/f13/sunny_dale)
 "eJm" = (
 /obj/structure/chair/f13/metal,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eJP" = (
 /obj/structure/closet/secure,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "eLP" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eMj" = (
 /obj/structure/chair/sofa/left,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "eMx" = (
@@ -6043,7 +6040,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "eNo" = (
@@ -6089,7 +6086,7 @@
 /area/f13)
 "ePo" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ePN" = (
@@ -6105,14 +6102,14 @@
 	},
 /area/f13/klamat)
 "eQJ" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "eQO" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "eQX" = (
@@ -6120,7 +6117,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "eQY" = (
@@ -6134,7 +6131,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "eRF" = (
@@ -6191,7 +6188,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "eUo" = (
@@ -6214,7 +6211,7 @@
 "eWo" = (
 /obj/structure/closet/cardboard,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "eWD" = (
@@ -6225,7 +6222,7 @@
 /obj/structure/mirror{
 	pixel_x = -32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "eWE" = (
@@ -6236,7 +6233,7 @@
 /obj/structure/mirror{
 	pixel_x = 32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "eXq" = (
@@ -6251,7 +6248,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "faC" = (
@@ -6286,7 +6283,7 @@
 /area/f13/klamat)
 "fbH" = (
 /obj/structure/curtain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "fbM" = (
@@ -6319,12 +6316,12 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "ffk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/wood,
 /area/f13/ncr_main)
 "ffu" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/f13/bedframe/metal,
@@ -6340,7 +6337,7 @@
 "ffW" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/kitchen/knife,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "fhM" = (
@@ -6352,13 +6349,13 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "fhY" = (
 /obj/machinery/door/unpowered/wooddoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "fiO" = (
@@ -6373,12 +6370,12 @@
 "fko" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "fkV" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/dresser/f13/orange,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "fll" = (
@@ -6398,7 +6395,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "fmk" = (
@@ -6424,7 +6421,7 @@
 /obj/structure/bookcase/random/reference{
 	pixel_y = -11
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/wood,
 /area/f13/sunny_dale)
 "fpd" = (
@@ -6458,7 +6455,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/ncr_main)
 "fqm" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 6
 	},
@@ -6479,7 +6476,7 @@
 "frB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/orange,
 /area/f13/sunny_dale)
 "frX" = (
@@ -6487,7 +6484,7 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "fsg" = (
@@ -6502,12 +6499,12 @@
 /area/f13/sunny_dale)
 "fwa" = (
 /obj/effect/landmark/start/f13/boss,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "fxL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/orange,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -6518,7 +6515,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/stairs{
 	dir = 1
 	},
@@ -6571,7 +6568,7 @@
 "fDa" = (
 /obj/structure/window/reinforced/tinted,
 /obj/structure/curtain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "fDi" = (
@@ -6586,7 +6583,7 @@
 "fDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/built{
 	dir = 8
 	},
@@ -6622,7 +6619,7 @@
 /area/f13/sunny_dale)
 "fFl" = (
 /obj/structure/weightmachine/stacklifter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "fGn" = (
@@ -6634,7 +6631,7 @@
 	},
 /area/f13)
 "fIv" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
@@ -6698,7 +6695,7 @@
 /area/f13/ncr_main)
 "fMa" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "fMJ" = (
@@ -6710,7 +6707,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/sunny_dale)
 "fNi" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -6732,20 +6729,14 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
-/area/f13/klamat)
-"fOx" = (
-/obj/structure/rack,
-/obj/item/soap,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "fOF" = (
 /obj/structure/rack,
 /obj/item/melee/classic_baton,
 /obj/item/melee/classic_baton,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "fOY" = (
@@ -6753,11 +6744,11 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "fPp" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/closet/cardboard,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -6846,7 +6837,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "fYF" = (
@@ -6854,17 +6845,10 @@
 	dir = 5
 	},
 /area/f13)
-"fZr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/floor/carpet/royalblack,
-/area/f13/sunny_dale)
 "fZZ" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "gap" = (
@@ -6919,7 +6903,7 @@
 /turf/open/floor/plasteel/f13/teal/_dirty,
 /area/f13/sunny_dale)
 "geC" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left3,
 /area/f13/sunny_dale)
 "geW" = (
@@ -6942,13 +6926,9 @@
 /area/f13/sunny_dale)
 "gfC" = (
 /obj/structure/punching_bag,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
-"ggk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/closed/wall/r_wall/f13/metal/rust,
-/area/f13/powerplant)
 "ggn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13/metal{
@@ -6989,8 +6969,8 @@
 /turf/open/floor/plating/ground/road/sidewalk,
 /area/f13)
 "giC" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -7013,16 +6993,16 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "gkK" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/mattress/stale,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "gkZ" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "gls" = (
@@ -7034,7 +7014,7 @@
 /obj/structure/bed/f13/sleepingbag/green,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "gmi" = (
@@ -7064,7 +7044,7 @@
 /area/f13/sunny_dale)
 "gqZ" = (
 /obj/machinery/light,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "grB" = (
@@ -7115,24 +7095,24 @@
 /obj/structure/mirror{
 	pixel_y = 31
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "gyi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "gyj" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "gzP" = (
 /obj/structure/table/low_wall/wood,
 /obj/structure/window/fulltile/f13/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "gzU" = (
@@ -7143,7 +7123,7 @@
 "gAn" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/dirty,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "gBn" = (
@@ -7167,7 +7147,7 @@
 /area/f13/sunny_dale)
 "gCl" = (
 /obj/structure/sign/warning/nosmoking,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/f13/metal/rust,
 /area/f13/klamat)
 "gCn" = (
@@ -7196,7 +7176,7 @@
 /area/f13/sunny_dale)
 "gEA" = (
 /obj/structure/closet/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "gEM" = (
@@ -7230,13 +7210,13 @@
 /area/f13/sunny_dale)
 "gJE" = (
 /obj/structure/chair/sofa/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "gJF" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "gJQ" = (
@@ -7258,7 +7238,7 @@
 "gMb" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/chair/comfy/black,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "gMc" = (
@@ -7271,7 +7251,7 @@
 /obj/structure/chair/comfy/f13/armchair{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "gNR" = (
@@ -7281,12 +7261,12 @@
 	},
 /area/f13/sunny_dale)
 "gOn" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/underground/bos)
 "gOr" = (
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "gPC" = (
@@ -7329,7 +7309,7 @@
 /obj/structure/chair/comfy/f13/ergo{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "gTi" = (
@@ -7349,7 +7329,7 @@
 	pixel_x = -12
 	},
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "gVM" = (
@@ -7357,7 +7337,7 @@
 	desc = "It's a dead plant. You can't tell what it used to be.";
 	name = "Dead Plant"
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "gWH" = (
@@ -7366,7 +7346,7 @@
 /area/f13/sunny_dale)
 "gWQ" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "gWY" = (
@@ -7389,7 +7369,7 @@
 "gYf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/chair/comfy/f13/retro{
 	dir = 8
 	},
@@ -7414,7 +7394,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "hbz" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/right1,
 /area/f13/sunny_dale)
 "hbH" = (
@@ -7426,7 +7406,7 @@
 "hca" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hcm" = (
@@ -7438,13 +7418,13 @@
 /area/f13/sunny_dale)
 "hcr" = (
 /obj/structure/closet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "hcS" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/pizzabox,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "hdq" = (
@@ -7459,7 +7439,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "heF" = (
@@ -7492,8 +7472,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "hgG" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/r_wall/f13/metal/rust,
 /area/f13/powerplant)
 "hgM" = (
@@ -7517,7 +7496,7 @@
 "hhO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hid" = (
@@ -7528,7 +7507,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "hik" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -7544,7 +7523,7 @@
 /area/f13/sunny_dale)
 "hiX" = (
 /obj/structure/table/f13/metal,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hkD" = (
@@ -7562,7 +7541,7 @@
 "hlj" = (
 /obj/structure/curtain,
 /obj/structure/window/reinforced/tinted,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "hlK" = (
@@ -7573,13 +7552,13 @@
 "hml" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/westright,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "hmo" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "hms" = (
@@ -7592,23 +7571,19 @@
 /area/f13/sunny_dale)
 "hnx" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/mattress/old,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hnC" = (
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
-"hoM" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/floor/plasteel/f13/_dirty,
-/area/f13/powerplant)
 "hpc" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "hpi" = (
@@ -7655,10 +7630,10 @@
 /turf/open/floor/plating/ground/road/sidewalk,
 /area/f13)
 "hsV" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/chair/office/f13/standard/blue{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "htC" = (
@@ -7668,7 +7643,7 @@
 "htO" = (
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/table/low_wall/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "htY" = (
@@ -7678,7 +7653,7 @@
 /area/f13/sunny_dale)
 "huw" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/f13/tv,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -7688,7 +7663,7 @@
 /area/f13/sunny_dale)
 "hwB" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/powerplant)
 "hwN" = (
@@ -7715,7 +7690,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hxF" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
@@ -7723,7 +7698,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hxU" = (
@@ -7737,7 +7712,7 @@
 /area/f13/sunny_dale)
 "hyh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -7776,10 +7751,6 @@
 	dir = 6
 	},
 /area/f13/sunny_dale)
-"hBy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/closed/indestructible/rock/f13,
-/area/f13/underground/mountain)
 "hCv" = (
 /obj/structure/rack,
 /obj/machinery/light/dim{
@@ -7790,7 +7761,7 @@
 "hCG" = (
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/table/low_wall/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/ncr_main)
 "hCK" = (
@@ -7829,7 +7800,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hGd" = (
@@ -7847,7 +7818,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hIc" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/brick,
 /area/f13/sunny_dale)
 "hIC" = (
@@ -7863,14 +7834,14 @@
 /turf/open/floor/plasteel/f13/teal/_dirty,
 /area/f13/sunny_dale)
 "hLd" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet,
 /area/f13/klamat)
 "hLN" = (
 /obj/structure/closet/crate/bin,
 /obj/item/paper/crumpled,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "hMc" = (
@@ -7929,7 +7900,7 @@
 "hPF" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/right,
 /area/f13/sunny_dale)
 "hQD" = (
@@ -7971,7 +7942,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "hUT" = (
@@ -8014,7 +7985,7 @@
 /area/f13/sunny_dale)
 "hWq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/right,
 /area/f13/sunny_dale)
 "hWt" = (
@@ -8072,7 +8043,7 @@
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/yellowed,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "ibQ" = (
@@ -8117,7 +8088,7 @@
 /area/f13)
 "igU" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "ihW" = (
@@ -8131,7 +8102,7 @@
 "ije" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -8164,7 +8135,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ikq" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/chair/comfy/f13/armchair,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 4
@@ -8177,17 +8148,17 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "imf" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "imt" = (
 /obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "ind" = (
@@ -8200,7 +8171,7 @@
 /area/f13/sunny_dale)
 "ipd" = (
 /obj/item/trash/can/food/peaches,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ipQ" = (
@@ -8208,14 +8179,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
-"irg" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/floor/plasteel/f13/_dirty,
-/area/f13/powerplant)
 "iri" = (
 /obj/structure/fireplace,
 /obj/effect/decal/cleanable/dirt,
@@ -8281,7 +8247,7 @@
 /area/f13)
 "ixZ" = (
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "iyn" = (
@@ -8308,7 +8274,7 @@
 /turf/open/floor/plasteel/f13/green,
 /area/f13/sunny_dale)
 "iBP" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "iBZ" = (
@@ -8337,13 +8303,13 @@
 /obj/structure/chair/f13/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "iDW" = (
 /obj/structure/table/low_wall/wood,
 /obj/structure/barricade/wooden/snowed,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "iEH" = (
@@ -8387,7 +8353,7 @@
 /obj/item/flashlight/lantern{
 	pixel_x = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "iIO" = (
@@ -8439,7 +8405,7 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "iLG" = (
@@ -8464,7 +8430,7 @@
 /turf/open/floor/plasteel/vaporwave,
 /area/space)
 "iNU" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full,
 /area/f13/underground/bos)
 "iOc" = (
@@ -8477,14 +8443,14 @@
 /area/f13/sunny_dale)
 "iOG" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left1,
 /area/f13/sunny_dale)
 "iPa" = (
 /obj/structure/chair/office/f13/standard{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "iPv" = (
@@ -8511,7 +8477,7 @@
 "iQz" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "iQN" = (
@@ -8560,7 +8526,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "iTt" = (
@@ -8596,14 +8562,14 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "iVo" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "iXk" = (
@@ -8620,7 +8586,7 @@
 /area/f13/sunny_dale)
 "iYN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/wood/f13/carpet/broken/right3,
 /area/f13/sunny_dale)
@@ -8631,7 +8597,7 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jaB" = (
@@ -8648,11 +8614,11 @@
 /area/f13)
 "jbP" = (
 /obj/structure/closet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "jcn" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left2,
 /area/f13/sunny_dale)
 "jcC" = (
@@ -8660,7 +8626,7 @@
 /obj/structure/chair/office/f13/standard/broken{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jde" = (
@@ -8672,7 +8638,7 @@
 /obj/structure/fence/corner{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "jgB" = (
@@ -8715,7 +8681,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "jmY" = (
@@ -8758,7 +8724,7 @@
 /area/f13/sunny_dale)
 "jow" = (
 /obj/structure/window/fulltile/f13/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -8800,19 +8766,19 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "jtM" = (
 /obj/structure/table/low_wall/brick,
 /obj/structure/barricade/wooden/snowed,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jud" = (
 /obj/machinery/door/unpowered/wooddoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jux" = (
@@ -8824,7 +8790,7 @@
 "juG" = (
 /obj/structure/table/low_wall/wood,
 /obj/effect/decal/cleanable/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jva" = (
@@ -8865,7 +8831,7 @@
 /area/f13/sunny_dale)
 "jzk" = (
 /obj/structure/toilet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "jzx" = (
@@ -8910,8 +8876,8 @@
 /turf/open/floor/plasteel/f13/_full/dirty,
 /area/f13/powerplant)
 "jBP" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -8933,7 +8899,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jEs" = (
@@ -8944,7 +8910,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "jEC" = (
@@ -8971,7 +8937,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jGn" = (
@@ -9000,7 +8966,7 @@
 /area/f13/sunny_dale)
 "jIm" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/f13/metal/rust,
 /area/f13/klamat)
 "jIH" = (
@@ -9019,20 +8985,20 @@
 /area/f13/sunny_dale)
 "jJD" = (
 /obj/structure/curtain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "jJI" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/torquise,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jJJ" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/stale,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "jKa" = (
@@ -9044,7 +9010,7 @@
 /obj/machinery/light/dim{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jKp" = (
@@ -9056,9 +9022,9 @@
 "jLh" = (
 /obj/structure/table/low_wall/brick,
 /obj/structure/window/fulltile/f13/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/curtain/cloth,
-/turf/open/floor/plating/roof,
+/turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jMg" = (
 /obj/effect/turf_decal/loading_area,
@@ -9082,7 +9048,7 @@
 /area/f13/sunny_dale)
 "jOX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
@@ -9105,7 +9071,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "jRn" = (
@@ -9114,7 +9080,7 @@
 /area/f13/sunny_dale)
 "jSc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/torquise,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
@@ -9148,7 +9114,7 @@
 /area/f13/sunny_dale)
 "jUr" = (
 /obj/item/shard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -9159,17 +9125,17 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "jVl" = (
 /obj/structure/closet/cardboard/metal,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "jWm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
@@ -9178,7 +9144,7 @@
 "jWz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/sandbags,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jXe" = (
@@ -9202,7 +9168,7 @@
 /area/f13/powerplant)
 "jYQ" = (
 /obj/structure/table/low_wall/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "jZF" = (
@@ -9215,7 +9181,7 @@
 /obj/structure/chair/sofa/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "kbh" = (
@@ -9238,7 +9204,7 @@
 	dir = 4
 	},
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "kbR" = (
@@ -9269,19 +9235,19 @@
 /turf/open/floor/plasteel/f13/white/dirty,
 /area/f13/sunny_dale)
 "kdl" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "kdq" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "kdt" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "kel" = (
@@ -9334,14 +9300,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "klz" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "klO" = (
@@ -9359,7 +9325,7 @@
 "knW" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "kob" = (
@@ -9392,7 +9358,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "kps" = (
@@ -9406,7 +9372,7 @@
 	dir = 4;
 	pixel_x = -15
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "kpB" = (
@@ -9421,7 +9387,7 @@
 /area/f13/sunny_dale)
 "ksM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/brick,
 /area/f13/sunny_dale)
 "ksZ" = (
@@ -9431,7 +9397,7 @@
 /area/f13/sunny_dale)
 "ktm" = (
 /obj/structure/dresser/f13/orange,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
@@ -9471,7 +9437,7 @@
 /area/f13)
 "kwJ" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/underground/bos)
 "kxn" = (
@@ -9482,18 +9448,18 @@
 /obj/structure/mirror{
 	pixel_x = -32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "kxw" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/stale,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "kyt" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/storage/toolbox/ammo,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -9510,7 +9476,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "kAu" = (
@@ -9558,7 +9524,7 @@
 "kDM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "kDN" = (
@@ -9570,7 +9536,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "kFF" = (
@@ -9582,7 +9548,7 @@
 /obj/structure/chair/comfy/f13/retro{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "kFZ" = (
@@ -9598,7 +9564,7 @@
 	},
 /area/f13/sunny_dale)
 "kGE" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plating/roof,
 /area/f13/sunny_dale)
 "kGU" = (
@@ -9642,7 +9608,7 @@
 "kMe" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "kMO" = (
@@ -9689,13 +9655,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "kPV" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "kPX" = (
@@ -9706,7 +9672,7 @@
 "kQV" = (
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "kRc" = (
@@ -9746,7 +9712,7 @@
 /area/f13/sunny_dale)
 "kUG" = (
 /obj/structure/window/reinforced/tinted,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "kUT" = (
@@ -9782,27 +9748,27 @@
 "kYC" = (
 /obj/structure/table/glass,
 /obj/machinery/chem_heater,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "kZg" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "kZq" = (
 /turf/open/floor/plasteel/f13/purple/side/dirty,
 /area/f13/powerplant)
 "kZF" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plating,
 /area/f13/klamat)
 "kZP" = (
 /obj/machinery/shower,
 /obj/structure/curtain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "lay" = (
@@ -9839,7 +9805,7 @@
 /area/f13/sunny_dale)
 "lbO" = (
 /obj/structure/closet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "lcj" = (
@@ -9891,12 +9857,12 @@
 	dir = 4
 	},
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "lgJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
@@ -9904,7 +9870,7 @@
 /obj/structure/chair/sofa{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "lhm" = (
@@ -9920,14 +9886,14 @@
 	dir = 4;
 	pixel_y = 15
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "lhJ" = (
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "lhP" = (
@@ -9952,7 +9918,7 @@
 /area/f13/powerplant)
 "ljw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "ljC" = (
@@ -9963,7 +9929,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lkv" = (
@@ -10061,7 +10027,7 @@
 /obj/structure/chair/office/f13/standard/blue{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "loQ" = (
@@ -10069,21 +10035,21 @@
 /area/f13/sunny_dale)
 "loR" = (
 /obj/structure/chair/stool,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "loW" = (
 /obj/structure/table/low_wall/brick,
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/curtain/cloth,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/floor/plating/roof,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lpI" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "lpV" = (
@@ -10110,14 +10076,14 @@
 "lsd" = (
 /obj/structure/table/low_wall/scrap,
 /obj/structure/window/fulltile/f13/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lsn" = (
 /obj/structure/chair/comfy/f13/armchair{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "lsW" = (
@@ -10125,7 +10091,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lta" = (
@@ -10138,7 +10104,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "ltI" = (
@@ -10153,7 +10119,7 @@
 /obj/item/flashlight/lantern{
 	pixel_x = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lur" = (
@@ -10185,7 +10151,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lxq" = (
@@ -10197,7 +10163,7 @@
 "lxA" = (
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "lyx" = (
@@ -10208,7 +10174,7 @@
 /area/f13/sunny_dale)
 "lyS" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "lBU" = (
@@ -10227,7 +10193,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lEc" = (
@@ -10252,7 +10218,7 @@
 /area/f13/powerplant)
 "lHt" = (
 /obj/structure/table/reinforced,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "lHR" = (
@@ -10271,7 +10237,7 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken1,
 /area/f13/sunny_dale)
 "lJP" = (
@@ -10283,7 +10249,7 @@
 "lJU" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lKR" = (
@@ -10314,7 +10280,7 @@
 /area/f13/sunny_dale)
 "lMt" = (
 /obj/structure/filingcabinet/medical,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "lML" = (
@@ -10353,7 +10319,7 @@
 /obj/structure/curtain/bounty,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "lOy" = (
@@ -10372,7 +10338,7 @@
 /area/f13)
 "lRI" = (
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "lSg" = (
@@ -10384,7 +10350,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "lSK" = (
@@ -10403,7 +10369,7 @@
 "lTA" = (
 /obj/structure/table/wood,
 /obj/item/phone,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "lTH" = (
@@ -10418,7 +10384,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "lUe" = (
@@ -10431,7 +10397,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lUL" = (
@@ -10441,7 +10407,7 @@
 "lVn" = (
 /obj/structure/table/wood,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lWv" = (
@@ -10462,7 +10428,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "lZZ" = (
@@ -10473,7 +10439,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "maJ" = (
@@ -10482,18 +10448,18 @@
 	},
 /area/f13)
 "mbo" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "mbA" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/dirty,
 /area/f13/klamat)
 "mce" = (
 /obj/structure/closet/cardboard/metal,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/dirty,
 /area/f13/klamat)
 "mcI" = (
@@ -10504,11 +10470,11 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
 /obj/effect/landmark/start/f13/sergeant,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "mcW" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "mdb" = (
@@ -10525,7 +10491,7 @@
 /area/f13/sunny_dale)
 "mev" = (
 /obj/structure/closet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "mfY" = (
@@ -10539,7 +10505,7 @@
 	},
 /area/f13/sunny_dale)
 "mgQ" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
@@ -10574,7 +10540,7 @@
 	dir = 8;
 	pixel_x = 15
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "mjk" = (
@@ -10639,17 +10605,17 @@
 "mop" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "mov" = (
 /obj/structure/dresser/f13/orange,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "moO" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "mqZ" = (
@@ -10677,7 +10643,7 @@
 /area/f13/sunny_dale)
 "mrD" = (
 /obj/structure/dresser/f13/orange,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left4,
 /area/f13/sunny_dale)
 "msv" = (
@@ -10694,7 +10660,7 @@
 /turf/open/floor/plasteel/f13/green/white/whitegreenchess,
 /area/f13/sunny_dale)
 "mtr" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/fallout/a308,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -10767,12 +10733,12 @@
 /obj/structure/chair/comfy/f13/retro{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "mAz" = (
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "mAR" = (
@@ -10789,7 +10755,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "mDy" = (
@@ -10806,17 +10772,17 @@
 /area/f13/sunny_dale)
 "mEB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/chair/office/f13/standard/broken{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "mFj" = (
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "mFJ" = (
@@ -10878,7 +10844,7 @@
 /area/f13/sunny_dale)
 "mKg" = (
 /obj/structure/bed/f13/bedframe/cot,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "mKh" = (
@@ -10913,11 +10879,11 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "mOk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "mPj" = (
@@ -10934,31 +10900,30 @@
 /area/f13/sunny_dale)
 "mRg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/orange,
 /turf/open/floor/carpet/orange,
 /area/f13/sunny_dale)
 "mRt" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/old,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "mRM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "mSe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "mSk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/powerplant)
 "mSQ" = (
@@ -10982,7 +10947,7 @@
 "mTs" = (
 /obj/structure/closet,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "mUc" = (
@@ -10994,7 +10959,7 @@
 /area/f13/sunny_dale)
 "mUH" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "mUI" = (
@@ -11026,7 +10991,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "mXd" = (
@@ -11042,7 +11007,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "mXU" = (
@@ -11073,7 +11038,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "mYR" = (
@@ -11086,7 +11051,7 @@
 "nan" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -11114,7 +11079,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "neB" = (
@@ -11128,7 +11093,7 @@
 /area/f13/sunny_dale)
 "nfk" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "ngs" = (
@@ -11146,13 +11111,13 @@
 /turf/open/transparent/openspace,
 /area/f13)
 "nho" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/filingcabinet,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "nht" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "nhE" = (
@@ -11160,13 +11125,13 @@
 /turf/open/floor/plasteel/f13/dark/full/rusty,
 /area/f13/powerplant)
 "njl" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/underground/bos)
 "njD" = (
 /obj/structure/table/low_wall/wood,
 /obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "nko" = (
@@ -11175,7 +11140,7 @@
 /area/f13/sunny_dale)
 "nkx" = (
 /obj/structure/bookcase/random,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -11236,8 +11201,8 @@
 /area/f13/sunny_dale)
 "nqa" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/filthy,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "nqz" = (
@@ -11282,7 +11247,7 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "ntK" = (
@@ -11299,7 +11264,7 @@
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ntZ" = (
@@ -11337,12 +11302,12 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "nwr" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/bedframe/wood,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -11362,7 +11327,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "nyp" = (
@@ -11376,8 +11341,8 @@
 /turf/open/floor/plating/ground/road/sidewalk,
 /area/f13/sunny_dale)
 "nyZ" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/dresser/f13/torquise,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "nzp" = (
@@ -11405,7 +11370,7 @@
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/green,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "nCa" = (
@@ -11430,7 +11395,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "nEF" = (
@@ -11454,7 +11419,7 @@
 /area/f13/sunny_dale)
 "nGg" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/powerplant)
 "nGm" = (
@@ -11463,14 +11428,14 @@
 /area/f13/sunny_dale)
 "nHe" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/stale,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "nHi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "nHk" = (
@@ -11527,7 +11492,7 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "nNa" = (
@@ -11550,7 +11515,7 @@
 /area/f13/powerplant)
 "nQJ" = (
 /obj/structure/chair/stool,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "nQW" = (
@@ -11571,7 +11536,7 @@
 /obj/structure/table/low_wall/wood,
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/curtain/cloth/fancy,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/ncr_main)
 "nRS" = (
@@ -11668,7 +11633,7 @@
 "nYx" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "nYY" = (
@@ -11682,12 +11647,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "nZZ" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/dirty,
 /area/f13/klamat)
 "oak" = (
@@ -11697,7 +11662,7 @@
 /area/f13/sunny_dale)
 "oaH" = (
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "oaN" = (
@@ -11707,17 +11672,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "obg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/wood,
 /area/f13/sunny_dale)
 "obH" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "obN" = (
@@ -11731,7 +11696,7 @@
 /area/f13/powerplant)
 "odj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -11768,7 +11733,7 @@
 /area/f13/sunny_dale)
 "ogI" = (
 /obj/structure/window,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "ogR" = (
@@ -11786,7 +11751,7 @@
 "oiB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/low_wall/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -11801,7 +11766,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/orange,
 /area/f13/sunny_dale)
 "oku" = (
@@ -11824,13 +11789,13 @@
 /obj/structure/chair/office/f13/standard{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ony" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "onz" = (
@@ -11868,7 +11833,7 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "opX" = (
@@ -11899,7 +11864,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "osI" = (
@@ -11912,7 +11877,7 @@
 /area/f13/ncr_main)
 "osV" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "otA" = (
@@ -11932,7 +11897,7 @@
 /area/f13/sunny_dale)
 "owf" = (
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "own" = (
@@ -11940,7 +11905,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "owQ" = (
@@ -11954,7 +11919,7 @@
 /area/f13/sunny_dale)
 "oxw" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "oxR" = (
@@ -11975,7 +11940,7 @@
 /obj/item/ammo_casing/c9mm,
 /obj/item/ammo_casing/c9mm,
 /obj/item/ammo_casing/c9mm,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
 "ozn" = (
@@ -11988,7 +11953,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "oAr" = (
@@ -12055,7 +12020,7 @@
 "oEp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/weightmachine/stacklifter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "oFc" = (
@@ -12063,12 +12028,12 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "oFo" = (
 /obj/machinery/iv_drip,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "oFt" = (
@@ -12164,7 +12129,7 @@
 "oKV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "oMM" = (
@@ -12180,7 +12145,7 @@
 /area/f13/sunny_dale)
 "oNv" = (
 /obj/structure/chair/office/f13/standard/broken,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "oOf" = (
@@ -12200,7 +12165,7 @@
 /area/f13/sunny_dale)
 "oQp" = (
 /obj/structure/bookcase/random,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "oQL" = (
@@ -12215,7 +12180,7 @@
 /area/f13/sunny_dale)
 "oQT" = (
 /obj/machinery/light/floor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "oRn" = (
@@ -12270,7 +12235,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "oUr" = (
@@ -12288,7 +12253,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "oVx" = (
@@ -12357,7 +12322,7 @@
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/powerplant)
 "pcy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/f13/metal/rust,
 /area/f13/klamat)
 "pcO" = (
@@ -12390,7 +12355,7 @@
 "pfa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/easel,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "pfz" = (
@@ -12403,12 +12368,12 @@
 /area/f13)
 "pgh" = (
 /obj/structure/fence/door,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "pgt" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "phe" = (
@@ -12448,7 +12413,7 @@
 /turf/open/floor/wood/f13/carpet/broken/left3,
 /area/f13/sunny_dale)
 "pjC" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 8
 	},
@@ -12475,7 +12440,7 @@
 /obj/machinery/shower{
 	pixel_y = 15
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "ple" = (
@@ -12487,20 +12452,20 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "plT" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/stale,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "pmc" = (
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "pmo" = (
@@ -12518,7 +12483,7 @@
 /turf/open/floor/plasteel/f13/blue/_dirty,
 /area/f13/sunny_dale)
 "pmT" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/powerplant)
 "pob" = (
@@ -12526,7 +12491,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "poH" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "ppu" = (
@@ -12554,7 +12519,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "pss" = (
@@ -12567,7 +12532,7 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "psS" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/table/low_wall/wood,
 /turf/open/floor/wood/f13,
@@ -12594,7 +12559,7 @@
 /area/f13/sunny_dale)
 "pvm" = (
 /obj/structure/table,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "pvT" = (
@@ -12607,14 +12572,14 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "pwM" = (
 /obj/item/storage/secure/safe{
 	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "pwU" = (
@@ -12655,7 +12620,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "pAu" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "pAI" = (
@@ -12683,7 +12648,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "pBT" = (
@@ -12698,7 +12663,7 @@
 "pDR" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "pEP" = (
@@ -12720,7 +12685,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "pFL" = (
@@ -12741,7 +12706,7 @@
 "pHe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser/f13/torquise,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "pHM" = (
@@ -12788,7 +12753,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "pLL" = (
@@ -12873,7 +12838,7 @@
 /area/f13/sunny_dale)
 "pSe" = (
 /obj/structure/chair/office/light,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "pSM" = (
@@ -12888,7 +12853,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "pTq" = (
@@ -12902,7 +12867,7 @@
 /turf/open/floor/plating/ground/road/sidewalk,
 /area/f13/sunny_dale)
 "pVh" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -12940,7 +12905,7 @@
 	pixel_x = 30
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "pXj" = (
@@ -12958,7 +12923,7 @@
 /obj/machinery/shower{
 	pixel_y = 19
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "pXZ" = (
@@ -12966,7 +12931,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "pYw" = (
@@ -13022,7 +12987,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "qcQ" = (
@@ -13036,20 +13001,20 @@
 	dir = 9
 	},
 /obj/item/ammo_casing/fallout/c45,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qde" = (
 /obj/structure/table/low_wall/brick,
 /obj/structure/window/fulltile/f13/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plating/roof,
 /area/f13/sunny_dale)
 "qdf" = (
 /obj/structure/chair/sofa{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qee" = (
@@ -13066,7 +13031,7 @@
 /turf/open/floor/plasteel/f13/white/rusty,
 /area/f13/sunny_dale)
 "qeI" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -13192,7 +13157,7 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qsI" = (
@@ -13223,7 +13188,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "quv" = (
@@ -13262,7 +13227,7 @@
 /area/f13/sunny_dale)
 "qAi" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "qAt" = (
@@ -13298,7 +13263,7 @@
 "qCZ" = (
 /obj/structure/table,
 /obj/item/phone,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "qDC" = (
@@ -13307,7 +13272,7 @@
 /area/f13/powerplant)
 "qDH" = (
 /obj/structure/noticeboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/f13/metal/rust,
 /area/f13/klamat)
 "qDW" = (
@@ -13332,7 +13297,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "qGK" = (
@@ -13428,7 +13393,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "qRv" = (
@@ -13450,17 +13415,17 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "qTj" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qTs" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qUe" = (
@@ -13470,7 +13435,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel,
 /area/f13/sunny_dale)
 "qUk" = (
@@ -13500,7 +13465,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qWg" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/chair/comfy/f13/armchair,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 8
@@ -13516,7 +13481,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qXy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
 /obj/item/rack_parts,
@@ -13536,7 +13501,7 @@
 /obj/structure/chair/f13/wood{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "qZn" = (
@@ -13566,7 +13531,7 @@
 "rbQ" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "rcd" = (
@@ -13601,14 +13566,14 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "rfz" = (
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "rfD" = (
@@ -13693,7 +13658,7 @@
 /area/f13/sunny_dale)
 "rlW" = (
 /obj/structure/table/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "rmk" = (
@@ -13708,18 +13673,18 @@
 /area/f13/ncr_main)
 "roy" = (
 /obj/structure/displaycase/noalert,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "roH" = (
 /obj/structure/table/low_wall/brick,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "roY" = (
 /obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "rpy" = (
@@ -13746,11 +13711,11 @@
 /area/f13/sunny_dale)
 "rqw" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "rqA" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "rqI" = (
@@ -13762,7 +13727,7 @@
 /area/f13/sunny_dale)
 "rqN" = (
 /obj/structure/bonfire,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/alt,
 /area/f13/sunny_dale)
 "rrL" = (
@@ -13785,7 +13750,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "rtt" = (
@@ -13803,7 +13768,7 @@
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "rve" = (
@@ -13820,19 +13785,19 @@
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "rvy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "rvW" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left1,
 /area/f13/sunny_dale)
 "rwj" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -13858,7 +13823,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -13878,7 +13843,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "rBi" = (
@@ -13903,24 +13868,24 @@
 "rCB" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "rDn" = (
 /obj/structure/chair/stool,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "rDu" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "rDz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "rFQ" = (
@@ -13932,7 +13897,7 @@
 /area/f13/sunny_dale)
 "rHD" = (
 /obj/structure/safe,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "rIa" = (
@@ -13953,7 +13918,7 @@
 "rJd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/built{
 	dir = 1
 	},
@@ -13978,12 +13943,12 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "rLl" = (
 /obj/structure/filingcabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "rLy" = (
@@ -13995,7 +13960,7 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "rMx" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 9
 	},
@@ -14047,7 +14012,7 @@
 "rPC" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/sleepingbag/green,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "rPH" = (
@@ -14074,7 +14039,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "rSR" = (
@@ -14084,7 +14049,7 @@
 /area/f13/sunny_dale)
 "rTb" = (
 /obj/structure/table/f13,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/powerplant)
 "rTg" = (
@@ -14102,24 +14067,24 @@
 /area/f13/sunny_dale)
 "rUi" = (
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/alt,
 /area/f13/sunny_dale)
 "rUl" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "rUn" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "rUV" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "rUX" = (
@@ -14170,7 +14135,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "saA" = (
@@ -14178,7 +14143,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "saD" = (
@@ -14206,7 +14171,7 @@
 /area/f13/sunny_dale)
 "scK" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "sdb" = (
@@ -14263,7 +14228,7 @@
 "sgp" = (
 /obj/structure/table/low_wall/metal/rust,
 /obj/structure/grille,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/full/rusty,
 /area/f13/sunny_dale)
 "sgQ" = (
@@ -14296,7 +14261,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "skY" = (
@@ -14345,24 +14310,24 @@
 /area/f13/sunny_dale)
 "soN" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "spa" = (
 /obj/structure/bookcase/random/reference{
 	pixel_y = -11
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/wood,
 /area/f13/sunny_dale)
 "spc" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "spd" = (
 /obj/machinery/iv_drip,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "spQ" = (
@@ -14373,7 +14338,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "sqa" = (
@@ -14390,14 +14355,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "sqn" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "sqz" = (
@@ -14408,7 +14373,7 @@
 "sqJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/easel,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "sqM" = (
@@ -14486,7 +14451,7 @@
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/red,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
 "sAD" = (
@@ -14505,12 +14470,12 @@
 /area/f13/sunny_dale)
 "sBv" = (
 /obj/structure/railing/corner,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "sBz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/carpet/orange,
 /area/f13/sunny_dale)
@@ -14562,18 +14527,18 @@
 "sGq" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "sGJ" = (
 /obj/structure/chair/f13/wood/padded,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "sGY" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/dirty,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "sJe" = (
@@ -14586,7 +14551,7 @@
 	pixel_x = 7
 	},
 /obj/item/reagent_containers/spray/pestspray,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "sJj" = (
@@ -14610,14 +14575,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "sKR" = (
 /obj/machinery/light/dim{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "sLB" = (
@@ -14629,12 +14594,12 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "sLN" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "sLX" = (
@@ -14647,7 +14612,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "sMo" = (
@@ -14655,7 +14620,7 @@
 /obj/structure/chair/office/f13/standard{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "sMt" = (
@@ -14666,12 +14631,12 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "sMR" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "sNl" = (
@@ -14691,7 +14656,7 @@
 /area/f13/klamat)
 "sOf" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "sOB" = (
@@ -14712,7 +14677,7 @@
 "sQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/mattress/filthy,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
@@ -14741,11 +14706,11 @@
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/sunny_dale)
 "sSf" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/right3,
 /area/f13/sunny_dale)
 "sTs" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -14821,7 +14786,7 @@
 "sZZ" = (
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/stained,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "taz" = (
@@ -14856,7 +14821,7 @@
 /area/f13/underground/bos)
 "tbP" = (
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "tcn" = (
@@ -14864,7 +14829,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tcC" = (
@@ -14875,7 +14840,7 @@
 /area/f13/sunny_dale)
 "tdj" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "tdl" = (
@@ -14897,7 +14862,7 @@
 "teh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/bedframe/metal,
 /obj/machinery/light/small,
 /turf/open/floor/carpet/royalblack,
@@ -14936,7 +14901,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "thI" = (
@@ -14955,7 +14920,7 @@
 "tiG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser/f13/orange,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tiJ" = (
@@ -14992,7 +14957,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "tjV" = (
@@ -15030,7 +14995,7 @@
 /area/f13/sunny_dale)
 "tma" = (
 /obj/structure/bookcase/random,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
@@ -15052,7 +15017,7 @@
 "tnH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
@@ -15067,7 +15032,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tpk" = (
@@ -15117,7 +15082,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "ttl" = (
@@ -15133,7 +15098,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "twd" = (
@@ -15144,7 +15109,7 @@
 "twB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "txj" = (
@@ -15170,7 +15135,7 @@
 	},
 /area/f13/sunny_dale)
 "tzn" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "tzI" = (
@@ -15181,7 +15146,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "tAj" = (
@@ -15216,7 +15181,7 @@
 "tBC" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tCs" = (
@@ -15240,7 +15205,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "tDh" = (
@@ -15262,7 +15227,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tEx" = (
@@ -15270,7 +15235,7 @@
 /obj/item/flashlight/lantern{
 	pixel_x = -9
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tEV" = (
@@ -15329,7 +15294,7 @@
 /area/f13/sunny_dale)
 "tJK" = (
 /obj/structure/barricade/wooden/snowed,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tKr" = (
@@ -15342,16 +15307,16 @@
 /area/f13/sunny_dale)
 "tKJ" = (
 /obj/structure/chair/comfy/f13/armchair,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "tLe" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/ncr_main)
 "tMk" = (
 /obj/structure/table/low_wall/brick,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plating/roof,
 /area/f13/sunny_dale)
 "tMn" = (
@@ -15385,7 +15350,7 @@
 /area/f13/sunny_dale)
 "tMK" = (
 /obj/structure/chair/stool,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "tNi" = (
@@ -15416,7 +15381,7 @@
 "tOR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tQk" = (
@@ -15424,7 +15389,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "tQz" = (
@@ -15448,7 +15413,7 @@
 /area/f13/sunny_dale)
 "tSd" = (
 /obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tSl" = (
@@ -15475,13 +15440,13 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "tTH" = (
 /obj/structure/rack,
 /obj/item/storage/bag/chemistry,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "tUf" = (
@@ -15512,7 +15477,7 @@
 /area/f13/sunny_dale)
 "tVo" = (
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/dirty,
 /area/f13/klamat)
 "tWm" = (
@@ -15537,7 +15502,7 @@
 /obj/structure/chair/comfy/f13/armchair{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tYV" = (
@@ -15548,7 +15513,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "tZD" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/side/dirty,
 /area/f13/sunny_dale)
 "uav" = (
@@ -15581,15 +15546,15 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ueW" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/r_wall/f13/bunker,
 /area/f13/underground/bos)
 "ugf" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
 /turf/open/floor/wood/f13,
@@ -15598,7 +15563,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/transparent/openspace,
 /area/f13/sunny_dale)
 "uiu" = (
@@ -15628,14 +15593,14 @@
 "uks" = (
 /obj/item/clothing/shoes/workboots,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ull" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "ulS" = (
@@ -15648,7 +15613,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/carpet/black,
 /area/f13/klamat)
 "umV" = (
@@ -15680,7 +15645,7 @@
 /area/f13/sunny_dale)
 "uqy" = (
 /obj/structure/chair/sofa,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "usa" = (
@@ -15703,7 +15668,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "uvi" = (
@@ -15712,7 +15677,7 @@
 /area/f13/sunny_dale)
 "uwf" = (
 /obj/machinery/smartfridge,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/wall/f13/metal/rust,
 /area/f13/klamat)
 "uwi" = (
@@ -15766,13 +15731,13 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "uAb" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full/rusty,
 /area/f13/underground/bos)
 "uBY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "uCa" = (
@@ -15784,7 +15749,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "uCS" = (
@@ -15813,7 +15778,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "uIX" = (
@@ -15832,7 +15797,7 @@
 /area/f13/sunny_dale)
 "uLz" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/left4,
 /area/f13/sunny_dale)
 "uLM" = (
@@ -15876,7 +15841,7 @@
 "uUq" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "uUt" = (
@@ -15900,7 +15865,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars,
 /obj/item/lighter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "uWV" = (
@@ -15921,7 +15886,7 @@
 /area/f13)
 "uXb" = (
 /obj/structure/lattice/catwalk,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "uXz" = (
@@ -15940,7 +15905,7 @@
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/table/low_wall/wood,
 /obj/structure/curtain/cloth/fancy,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/ncr_main)
 "uZc" = (
@@ -15952,7 +15917,7 @@
 /obj/structure/table/low_wall/brick,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vao" = (
@@ -15965,12 +15930,12 @@
 	pixel_y = 12
 	},
 /obj/structure/table/f13/metal,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vaC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/orange/pristine,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
@@ -15983,7 +15948,7 @@
 /turf/open/floor/wood/f13/carpet/broken/left4,
 /area/f13/sunny_dale)
 "vdT" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/closed/indestructible/rock/f13,
 /area/f13/klamat)
 "vdZ" = (
@@ -15996,14 +15961,14 @@
 "veD" = (
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/green,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "veS" = (
 /obj/structure/table/low_wall/wood,
 /obj/structure/window/fulltile/f13/glass,
 /obj/structure/curtain/cloth,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "vfy" = (
@@ -16016,13 +15981,13 @@
 "vgH" = (
 /obj/structure/table/wood,
 /obj/item/paper/crumpled,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vgU" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/brick,
 /area/f13/sunny_dale)
 "vhD" = (
@@ -16038,22 +16003,22 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vjv" = (
 /obj/structure/table/f13/round,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vjR" = (
 /obj/structure/chair/f13/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vkm" = (
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "vkw" = (
@@ -16061,7 +16026,7 @@
 /area/f13/sunny_dale)
 "vla" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "vlq" = (
@@ -16071,12 +16036,12 @@
 /obj/machinery/light/dim{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vlM" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -16089,12 +16054,12 @@
 /obj/structure/mirror{
 	pixel_x = 32
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
 "vmm" = (
 /obj/structure/fence,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "vnh" = (
@@ -16102,7 +16067,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "voE" = (
@@ -16115,25 +16080,25 @@
 /area/f13/sunny_dale)
 "voU" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "vqq" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/item/soap,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "vrH" = (
 /obj/structure/chair/f13/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vsb" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 1
 	},
@@ -16144,14 +16109,14 @@
 	},
 /area/f13/sunny_dale)
 "vsm" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "vsq" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_rusty,
 /area/f13/underground/bos)
 "vtc" = (
@@ -16161,7 +16126,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
 /obj/effect/landmark/start/f13/lieutenant,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "vve" = (
@@ -16169,19 +16134,19 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vvh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "vvj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/easel,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken1,
 /area/f13/sunny_dale)
 "vwC" = (
@@ -16196,12 +16161,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "vyl" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/mattress/stale,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -16209,12 +16174,12 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "vzF" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "vzI" = (
@@ -16237,8 +16202,8 @@
 /turf/open/floor/plasteel/f13/_dirty,
 /area/f13/sunny_dale)
 "vAS" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/orange,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -16261,7 +16226,7 @@
 "vEt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vEF" = (
@@ -16282,7 +16247,7 @@
 	dir = 1
 	},
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vGz" = (
@@ -16307,20 +16272,20 @@
 /area/f13/sunny_dale)
 "vGQ" = (
 /obj/structure/closet/cardboard,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "vHW" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/carpet/royalblack,
 /area/f13/sunny_dale)
 "vIr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vIW" = (
@@ -16330,11 +16295,11 @@
 /area/f13/sunny_dale)
 "vJo" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "vJx" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -16346,22 +16311,22 @@
 /area/f13/sunny_dale)
 "vLE" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "vMH" = (
 /obj/machinery/door/unpowered/wooddoor,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "vOa" = (
 /obj/structure/dresser/f13/orange,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "vOq" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/dresser/f13/torquise,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13,
@@ -16374,12 +16339,12 @@
 /obj/structure/chair/office/f13/standard{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vPv" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
 "vQm" = (
@@ -16395,8 +16360,8 @@
 /area/f13/sunny_dale)
 "vRp" = (
 /obj/structure/table/low_wall/brick,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -16411,7 +16376,7 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "vRy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -16421,8 +16386,8 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "vSc" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "vTG" = (
@@ -16437,12 +16402,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "vUx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "vVw" = (
@@ -16450,7 +16415,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "vVA" = (
@@ -16459,7 +16424,7 @@
 /area/f13/sunny_dale)
 "vVI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
@@ -16474,14 +16439,14 @@
 /area/f13/sunny_dale)
 "vXH" = (
 /obj/structure/closet/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "vXN" = (
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "vXS" = (
@@ -16495,13 +16460,13 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "vYU" = (
 /obj/structure/table/wood,
 /obj/structure/f13/tv,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "vZX" = (
@@ -16510,18 +16475,18 @@
 /area/f13/sunny_dale)
 "waJ" = (
 /obj/machinery/light/small,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "wbT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wcd" = (
 /obj/structure/chair/stool,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "wci" = (
@@ -16578,7 +16543,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wio" = (
@@ -16586,7 +16551,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "wiA" = (
@@ -16610,7 +16575,7 @@
 /turf/open/floor/plasteel/f13/blue/white/whitebluechess/dirty,
 /area/f13/sunny_dale)
 "wjq" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/bedframe/wood,
 /obj/structure/bed/f13/mattress/stained,
 /turf/open/floor/wood/f13,
@@ -16626,8 +16591,8 @@
 /turf/open/floor/plasteel/f13/white/rusty,
 /area/f13/sunny_dale)
 "wjz" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/bed/f13/bedframe/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/f13/mattress/filthy,
@@ -16668,22 +16633,22 @@
 "wmG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "wnk" = (
 /obj/structure/dresser/f13/torquise,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wnE" = (
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/red,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "woi" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "woA" = (
@@ -16701,18 +16666,18 @@
 /obj/machinery/door/unpowered/wooddoor{
 	state_open = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wrB" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "wsi" = (
 /obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wsY" = (
@@ -16722,8 +16687,8 @@
 /area/f13/sunny_dale)
 "wtb" = (
 /obj/structure/bed/f13/bedframe/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/mattress/yellowed,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "wtn" = (
@@ -16746,13 +16711,13 @@
 "wuE" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "wvg" = (
 /obj/structure/table/f13/metal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wvj" = (
@@ -16764,7 +16729,7 @@
 "wvr" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wwO" = (
@@ -16776,7 +16741,7 @@
 	name = "premium cigar case"
 	},
 /obj/item/storage/box/matches,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "wyc" = (
@@ -16793,7 +16758,7 @@
 /area/f13/sunny_dale)
 "wzb" = (
 /obj/structure/table/low_wall/brick,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -16835,19 +16800,19 @@
 /area/f13)
 "wCL" = (
 /obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "wCN" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/filthy,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "wCR" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "wDI" = (
@@ -16860,7 +16825,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "wEx" = (
@@ -16874,12 +16839,12 @@
 /area/f13/sunny_dale)
 "wEB" = (
 /obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
 "wFg" = (
 /obj/item/trash/can/food/beans,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wHL" = (
@@ -16896,7 +16861,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wIW" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken/right4,
 /area/f13/sunny_dale)
 "wJl" = (
@@ -16916,7 +16881,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/_dirty,
 /area/f13/sunny_dale)
 "wKZ" = (
@@ -16945,7 +16910,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "wNg" = (
@@ -16972,11 +16937,11 @@
 /area/f13/sunny_dale)
 "wOi" = (
 /obj/structure/barricade/wooden,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/right,
 /area/f13/sunny_dale)
 "wOk" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /turf/open/floor/wood/f13,
@@ -16990,19 +16955,19 @@
 	},
 /area/f13/sunny_dale)
 "wPU" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/_full/dirty,
 /area/f13/underground/bos)
 "wQh" = (
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "wRw" = (
 /obj/structure/filingcabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "wSc" = (
@@ -17031,7 +16996,7 @@
 	},
 /area/f13/sunny_dale)
 "wUF" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
@@ -17053,19 +17018,19 @@
 /area/f13/klamat)
 "wWS" = (
 /obj/structure/dresser/f13/torquise,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "wXA" = (
 /obj/structure/closet/cardboard,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "wYb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "wYG" = (
@@ -17079,7 +17044,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xak" = (
@@ -17100,7 +17065,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "xbR" = (
@@ -17114,7 +17079,7 @@
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "xcp" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/fallout/c9mm/junk,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
@@ -17122,13 +17087,13 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "xdg" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "xdK" = (
@@ -17138,7 +17103,7 @@
 "xeF" = (
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/green,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "xeL" = (
@@ -17154,7 +17119,7 @@
 "xeQ" = (
 /obj/machinery/door/unpowered/wooddoor,
 /obj/structure/barricade/wooden/crude,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xeZ" = (
@@ -17177,7 +17142,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/f13/sunny_dale)
 "xfy" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
 "xfz" = (
@@ -17192,7 +17157,7 @@
 	},
 /area/f13/sunny_dale)
 "xgc" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -17214,7 +17179,7 @@
 /area/f13/sunny_dale)
 "xic" = (
 /obj/structure/barricade/sandbags,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xih" = (
@@ -17231,14 +17196,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "xln" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plastic,
 /area/f13/sunny_dale)
 "xls" = (
 /turf/open/floor/plating/ground/road,
 /area/f13/sunny_dale)
 "xlu" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/plasteel/f13/red/side/dirty{
 	dir = 10
 	},
@@ -17248,7 +17213,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "xmy" = (
@@ -17263,7 +17228,7 @@
 /area/f13/sunny_dale)
 "xmI" = (
 /obj/structure/rack,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "xnk" = (
@@ -17283,7 +17248,7 @@
 "xnE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xoN" = (
@@ -17296,14 +17261,14 @@
 /area/f13/underground/mountain)
 "xpB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken,
 /area/f13/sunny_dale)
 "xpW" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "xqC" = (
@@ -17320,14 +17285,14 @@
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/stained,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xsB" = (
 /obj/structure/rack,
 /obj/item/roller,
 /obj/item/roller,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "xtr" = (
@@ -17352,19 +17317,19 @@
 /area/f13/sunny_dale)
 "xvk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/left,
 /area/f13/sunny_dale)
 "xvG" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "xwo" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "xwy" = (
@@ -17373,7 +17338,7 @@
 /area/f13)
 "xwS" = (
 /obj/structure/railing,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "xxB" = (
@@ -17395,7 +17360,7 @@
 /area/f13/sunny_dale)
 "xyc" = (
 /obj/machinery/photocopier,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "xyd" = (
@@ -17403,14 +17368,10 @@
 	dir = 6
 	},
 /area/f13/sunny_dale)
-"xyO" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/closed/wall/f13/metal/rust,
-/area/f13/sunny_dale)
 "xyX" = (
 /obj/structure/table/wood,
 /obj/item/cigbutt/cigarbutt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "xzv" = (
@@ -17425,8 +17386,8 @@
 /turf/open/floor/wood/f13,
 /area/f13)
 "xAg" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/right,
 /area/f13/sunny_dale)
 "xBg" = (
@@ -17449,8 +17410,8 @@
 /turf/open/floor/plating/ground/road/sidewalk,
 /area/f13)
 "xDv" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken2,
 /area/f13/sunny_dale)
 "xDO" = (
@@ -17462,8 +17423,8 @@
 /area/f13/sunny_dale)
 "xDS" = (
 /obj/structure/barricade/sandbags,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xEh" = (
@@ -17484,7 +17445,7 @@
 /area/f13/sunny_dale)
 "xGL" = (
 /obj/structure/table/low_wall/brick,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xHg" = (
@@ -17505,7 +17466,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "xKl" = (
@@ -17513,7 +17474,7 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "xKq" = (
@@ -17532,13 +17493,13 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
 "xMI" = (
 /obj/structure/bed/f13/bedframe/metal,
 /obj/structure/bed/f13/mattress/yellowed,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet/broken,
 /area/f13/sunny_dale)
 "xNp" = (
@@ -17559,7 +17520,7 @@
 	},
 /obj/item/clothing/shoes/fallout/military/ncr_officer,
 /obj/item/lipstick,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "xOj" = (
@@ -17578,7 +17539,7 @@
 /area/f13/sunny_dale)
 "xPg" = (
 /obj/structure/barricade/sandbags,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/broken/slightlybroken1,
 /area/f13/sunny_dale)
 "xPi" = (
@@ -17589,7 +17550,7 @@
 "xPm" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "xPS" = (
@@ -17610,7 +17571,7 @@
 "xQe" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/storage/briefcase/lawyer,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "xQj" = (
@@ -17620,7 +17581,7 @@
 /area/f13/sunny_dale)
 "xQC" = (
 /obj/structure/table/wood,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/toy/cards/deck,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ncr_main)
@@ -17637,7 +17598,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/transparent/openspace,
 /area/f13/klamat)
 "xSs" = (
@@ -17660,12 +17621,12 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "xUr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -17675,7 +17636,7 @@
 /area/f13/sunny_dale)
 "xUX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -17685,7 +17646,7 @@
 /obj/machinery/light/dim{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "xWm" = (
@@ -17693,8 +17654,8 @@
 /turf/open/floor/wood/f13/broken/right,
 /area/f13/sunny_dale)
 "xXl" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/closed/wall/f13/brick,
 /area/f13/sunny_dale)
 "xXx" = (
@@ -17730,20 +17691,20 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "xYG" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/mattress/stained,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "xZC" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "yac" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "yai" = (
@@ -17764,9 +17725,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/sunny_dale)
 "ybz" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/bed/f13/bedframe/wire,
 /obj/structure/bed/f13/mattress/stained,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "ycr" = (
@@ -17782,7 +17743,7 @@
 /area/f13/sunny_dale)
 "ycO" = (
 /obj/structure/closet/cabinet,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood,
 /area/f13/ncr_main)
 "ydt" = (
@@ -17793,7 +17754,7 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "yeT" = (
@@ -17805,7 +17766,7 @@
 "yfH" = (
 /obj/structure/table/low_wall/brick,
 /obj/structure/window/fulltile/f13/glass,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "ygx" = (
@@ -17818,7 +17779,7 @@
 /turf/open/floor/wood/f13,
 /area/f13/ncr_main)
 "ygS" = (
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/structure/table/low_wall/brick,
 /obj/structure/window/fulltile/f13/glass,
 /turf/open/floor/wood/f13/broken,
@@ -17826,7 +17787,7 @@
 "yiC" = (
 /obj/structure/filingcabinet/medical,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/wood/f13,
 /area/f13/klamat)
 "yiP" = (
@@ -17848,7 +17809,7 @@
 /obj/structure/bed/f13/bedframe/cot,
 /obj/structure/bed/f13/sleepingbag/red,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/sunny_dale)
 "yln" = (
@@ -17868,7 +17829,7 @@
 	brightness = 3;
 	dir = 8
 	},
-/obj/effect/mapping_helpers/sunlight/roofSetter,
+/obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
 /turf/open/floor/plasteel/f13/misc/cafeteria,
 /area/f13/klamat)
 "ymd" = (
@@ -166550,13 +166511,13 @@ eET
 eET
 eET
 eET
-xyO
-xyO
-xyO
+wiA
+wiA
+wiA
 sgp
-xyO
-xyO
-xyO
+wiA
+wiA
+wiA
 eET
 eET
 eET
@@ -167880,13 +167841,13 @@ afK
 aiz
 aag
 afK
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
 afK
 afK
 afK
@@ -168142,26 +168103,26 @@ afK
 aiz
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
 afK
 afK
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
 afK
 afK
 afK
@@ -168404,26 +168365,26 @@ aiz
 aiz
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -168666,26 +168627,26 @@ aiz
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -168928,26 +168889,26 @@ aiz
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -169190,26 +169151,26 @@ aiz
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
 afK
 afK
 afK
@@ -169452,24 +169413,24 @@ aiz
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -169714,24 +169675,24 @@ aiz
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -169976,24 +169937,24 @@ aiz
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -170238,24 +170199,24 @@ aiz
 afK
 afK
 afK
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-ggk
-hBy
-hBy
-hBy
-ggk
-hoM
-hoM
-hoM
-ggk
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+hgG
+afK
+afK
+afK
+hgG
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -170506,18 +170467,18 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-ggk
-ggk
+hgG
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+hgG
+hgG
 afK
 afK
 afK
@@ -170768,17 +170729,17 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
+hgG
+mSk
+mSk
 hwB
 pmT
 pmT
 nGg
-hoM
-hoM
-hoM
-ggk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -171030,22 +170991,22 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
+hgG
+mSk
+mSk
 hwB
 pmT
 pmT
 nGg
-hoM
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
+mSk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
 afK
 aiz
 aab
@@ -171292,22 +171253,22 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
+hgG
+mSk
+mSk
+mSk
 hwB
 nGg
-hoM
-hoM
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
-ggk
+mSk
+mSk
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 aiz
 aiz
@@ -171554,23 +171515,23 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
 hgG
-ggk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+hgG
+hgG
 afK
 aiz
 aab
@@ -171816,24 +171777,24 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-ggk
-hBy
-hBy
-hBy
-ggk
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
+hgG
 mSk
-irg
-ggk
+mSk
+hgG
+afK
+afK
+afK
+hgG
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 aiz
 aab
 aab
@@ -172078,23 +172039,23 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
+hgG
 mSk
-irg
+mSk
+hgG
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
 aYv
 aiz
 aab
@@ -172340,23 +172301,23 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
+hgG
 mSk
-irg
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
 aYv
 aiz
 aab
@@ -172602,23 +172563,23 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
-hoM
-hoM
-hoM
-hoM
+hgG
 mSk
-irg
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
 aYv
 aiz
 aab
@@ -172864,24 +172825,24 @@ afK
 afK
 afK
 afK
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-hoM
-hoM
+hgG
+hgG
+hgG
+hgG
 mSk
-irg
-ggk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 aiz
 aab
 aab
@@ -173129,20 +173090,20 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-ggk
-hBy
-hBy
-ggk
-hoM
-hoM
-hoM
-hoM
 hgG
-ggk
+mSk
+mSk
+mSk
+hgG
+afK
+afK
+hgG
+mSk
+mSk
+mSk
+mSk
+hgG
+hgG
 afK
 aiz
 aab
@@ -173391,19 +173352,19 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-ggk
-hBy
-hBy
-ggk
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+hgG
+afK
+afK
+hgG
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 aiz
 aiz
@@ -173653,19 +173614,19 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-ggk
-hBy
-hBy
-ggk
-ggk
-ggk
-ggk
-ggk
-ggk
+hgG
+mSk
+mSk
+mSk
+hgG
+afK
+afK
+hgG
+hgG
+hgG
+hgG
+hgG
+hgG
 afK
 aiz
 aab
@@ -173912,17 +173873,17 @@ afK
 afK
 afK
 afK
-ggk
-ggk
-ggk
-ggk
-hoM
-hoM
-hoM
-ggk
-ggk
-ggk
-ggk
+hgG
+hgG
+hgG
+hgG
+mSk
+mSk
+mSk
+hgG
+hgG
+hgG
+hgG
 afK
 afK
 afK
@@ -174174,16 +174135,16 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -174436,16 +174397,16 @@ afK
 afK
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-hoM
-ggk
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+mSk
+hgG
 afK
 afK
 afK
@@ -174698,16 +174659,16 @@ aiz
 aiz
 afK
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
 rTb
 rTb
-hoM
-ggk
+mSk
+hgG
 afK
 afK
 aiz
@@ -174960,16 +174921,16 @@ aiz
 aiz
 aiz
 afK
-ggk
-hoM
-hoM
-hoM
-hoM
-hoM
+hgG
+mSk
+mSk
+mSk
+mSk
+mSk
 rTb
-hoM
-hoM
-ggk
+mSk
+mSk
+hgG
 afK
 aiz
 aiz
@@ -175222,16 +175183,16 @@ aiz
 aiz
 aiz
 afK
-ggk
-ggk
+hgG
+hgG
 aYv
 aYv
 aYv
-ggk
-ggk
-hoM
-hoM
-ggk
+hgG
+hgG
+mSk
+mSk
+hgG
 afK
 aiz
 aiz
@@ -175490,10 +175451,10 @@ aiz
 aiz
 aiz
 aiz
-ggk
-ggk
-ggk
-ggk
+hgG
+hgG
+hgG
+hgG
 afK
 aiz
 aiz
@@ -192162,7 +192123,7 @@ rqw
 pAu
 tMK
 pAu
-fOx
+vqq
 pcy
 pcy
 pcy
@@ -194366,7 +194327,7 @@ aab
 aab
 hIc
 dTk
-aWV
+aTy
 hIc
 imf
 imf
@@ -194628,7 +194589,7 @@ aab
 aab
 hIc
 dTk
-aWV
+aTy
 hIc
 vOq
 wjq
@@ -202903,12 +202864,12 @@ pcy
 pcy
 kZF
 pcy
-aVB
+pcy
 afK
 pcy
 kZF
 pcy
-aaf
+vdT
 pcy
 kZF
 pcy
@@ -204965,19 +204926,19 @@ afK
 afK
 afK
 afK
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
-aVB
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
+pcy
 pcy
 kZF
 pcy
@@ -225992,7 +225953,7 @@ igj
 aTc
 vHW
 jWm
-fZr
+mSe
 mSe
 teh
 aTc
@@ -226516,7 +226477,7 @@ igj
 hyh
 aTu
 aBx
-aUU
+aTc
 aab
 aab
 aab
@@ -228556,7 +228517,7 @@ afK
 afK
 afK
 afK
-aTq
+ueW
 ueW
 ueW
 imt
@@ -228817,8 +228778,8 @@ afK
 afK
 afK
 afK
-aTq
-aTq
+ueW
+ueW
 rqA
 rqA
 rqA
@@ -229079,7 +229040,7 @@ afK
 afK
 afK
 afK
-aTq
+ueW
 afN
 rqA
 gOn
@@ -229341,8 +229302,8 @@ afK
 afK
 afK
 afK
-aTq
-apn
+ueW
+dxq
 rqA
 lHt
 rqA
@@ -229603,8 +229564,8 @@ afK
 afK
 afK
 afK
-aTq
-apn
+ueW
+dxq
 rqA
 aNj
 rqA
@@ -229865,8 +229826,8 @@ afK
 afK
 afK
 afK
-aTq
-aTq
+ueW
+ueW
 aMz
 aNj
 vsq
@@ -230128,7 +230089,7 @@ afK
 afK
 afK
 afK
-aTq
+ueW
 ueW
 ueW
 ueW
@@ -231176,7 +231137,7 @@ afK
 afK
 afK
 afK
-aTq
+ueW
 ueW
 ueW
 ueW
@@ -231437,8 +231398,8 @@ afK
 afK
 afK
 afK
-aTq
-aTq
+ueW
+ueW
 aMz
 lHt
 kdt
@@ -231699,8 +231660,8 @@ afK
 afK
 afK
 afK
-aTq
-aMs
+ueW
+kwJ
 pSe
 lHt
 rqA
@@ -231961,8 +231922,8 @@ afK
 afK
 afK
 afK
-aTq
-apn
+ueW
+dxq
 rqA
 lHt
 rqA
@@ -232223,7 +232184,7 @@ afK
 afK
 afK
 afK
-aTq
+ueW
 afN
 rqA
 rqA
@@ -232485,8 +232446,8 @@ afK
 afK
 afK
 afK
-aTq
-aTq
+ueW
+ueW
 rqA
 rqA
 rqA
@@ -232748,7 +232709,7 @@ afK
 afK
 afK
 afK
-aTq
+ueW
 ueW
 ueW
 imt


### PR DESCRIPTION
## About The Pull Request

Roof setters were not working properly because people were using the base type, instead of the wood child type.
This replaces the base type with either wood or mountain as appropriate, and fixes some spots that had wood but should have used mountain or the other way around..

## Why It's Good For The Game

Makes the lighting work as intended, sets the stage (hopefully) for multi-z floor construction/deconstruction.