### PR TITLE
Comment out a certain shuttle proc.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -361,6 +361,7 @@ SUBSYSTEM_DEF(shuttle)
 		//Make all cargo consoles speak up
 
 /datum/controller/subsystem/shuttle/proc/checkHostileEnvironment()
+/* FALLOUT 13: This causes a runtime and we don't particularly need shuttles for anything.
 	for(var/datum/d in hostileEnvironments)
 		if(!istype(d) || QDELETED(d))
 			hostileEnvironments -= d
@@ -379,6 +380,7 @@ SUBSYSTEM_DEF(shuttle)
 		priority_announce("Hostile environment resolved. \
 			You have 3 minutes to board the Emergency Shuttle.",
 			null, 'sound/ai/shuttledock.ogg', "Priority")
+*/
 
 //try to move/request to dockHome if possible, otherwise dockAway. Mainly used for admin buttons
 /datum/controller/subsystem/shuttle/proc/toggleShuttle(shuttleId, dockHome, dockAway, timed)


### PR DESCRIPTION
## About The Pull Request

This comments out a proc that was causing another runtime.
My rationale is that we probably are never going to need to use emergency shuttle code.

## Why It's Good For The Game

Runtimes stink.
