### PR TITLE
Fix ladder types on Mammoth.

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -210,7 +210,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/f13/sunny_dale)
 "acm" = (
-/obj/structure/ladder/unbreakable,
+/obj/structure/ladder,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/underground/cave)
 "acn" = (
@@ -682,7 +682,7 @@
 /turf/open/floor/plasteel/f13/dark/dirty,
 /area/f13/klamat)
 "aji" = (
-/obj/structure/ladder/unbreakable,
+/obj/structure/ladder,
 /turf/open/floor/plasteel/f13/dark/rusty,
 /area/f13/klamat)
 "ajs" = (
@@ -3664,7 +3664,7 @@
 /turf/open/floor/plasteel/f13/misc/rarewhite/rarewhitechess,
 /area/f13/klamat)
 "aYi" = (
-/obj/structure/ladder/unbreakable,
+/obj/structure/ladder,
 /turf/open/floor/plasteel/f13/dark,
 /area/f13/klamat)
 "aYl" = (


### PR DESCRIPTION
## About The Pull Request

We were using /obj/structure/ladder/unbreakable
This is why ladders don't work, they're coded for TG away missions.
From now on we shall use only /obj/structure/ladder , or perhaps our own homemade unbreakable version.

## Why It's Good For The Game

Ladders are useful and needed, and we shouldn't rely only on stairs.
