### PR TITLE
Openspace variant that players can't build on.

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aab" = (
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "aac" = (
 /turf/closed/mineral/random/f13,
@@ -676,7 +676,7 @@
 /area/f13/sunny_dale)
 "aja" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "ajb" = (
 /obj/machinery/light/small{
@@ -845,7 +845,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "alo" = (
 /obj/machinery/power/smes,
@@ -1181,7 +1181,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "aqW" = (
 /obj/structure/table,
@@ -1544,7 +1544,7 @@
 /area/f13)
 "awS" = (
 /obj/structure/railing,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "awT" = (
 /obj/structure/janitorialcart,
@@ -2046,7 +2046,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aIl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2357,7 +2357,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aLj" = (
 /obj/machinery/door/unpowered/wooddoor,
@@ -2521,7 +2521,7 @@
 "aMy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aMz" = (
 /obj/structure/filingcabinet,
@@ -2786,7 +2786,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aPh" = (
 /turf/open/floor/plasteel/f13/red/side/dirty{
@@ -2798,7 +2798,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aPm" = (
 /obj/structure/sink/kitchen{
@@ -2844,7 +2844,7 @@
 /turf/open/floor/plasteel/f13/white/full,
 /area/f13/sunny_dale)
 "aPC" = (
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aPD" = (
 /obj/structure/stairs{
@@ -3009,7 +3009,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aQV" = (
 /obj/structure/dresser/f13/orange/pristine,
@@ -3045,19 +3045,19 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aRj" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aRk" = (
 /obj/structure/railing/corner,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aRm" = (
 /obj/structure/table/glass,
@@ -3271,7 +3271,7 @@
 /area/f13/klamat)
 "aTy" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "aTA" = (
 /obj/machinery/door/poddoor/shutters,
@@ -3280,7 +3280,7 @@
 "aTC" = (
 /obj/machinery/light/small,
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "aTI" = (
 /turf/open/floor/plasteel/f13,
@@ -3290,7 +3290,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aTK" = (
 /obj/structure/closet/cardboard,
@@ -3450,7 +3450,7 @@
 /area/f13/underground/cave)
 "aVw" = (
 /obj/structure/lattice/catwalk,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "aVy" = (
 /turf/open/floor/wood/f13/broken,
@@ -3560,7 +3560,7 @@
 /turf/open/floor/plasteel/f13/misc/rarewhite,
 /area/f13/klamat)
 "aWV" = (
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "aWY" = (
 /obj/structure/table/wood,
@@ -4145,7 +4145,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "bsq" = (
 /obj/structure/filingcabinet,
@@ -4683,7 +4683,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "cgC" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter,
@@ -4809,7 +4809,7 @@
 "ctD" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/machinery/light/small/broken,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "ctK" = (
 /obj/structure/table/wood,
@@ -5274,7 +5274,7 @@
 "deU" = (
 /obj/structure/railing,
 /obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/powerplant)
 "dfm" = (
 /obj/machinery/light/small/broken{
@@ -5900,7 +5900,7 @@
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "efF" = (
 /obj/structure/fence/fencenormal,
@@ -6350,7 +6350,7 @@
 	},
 /obj/structure/railing,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "eIT" = (
 /obj/item/restraints/legcuffs/beartrap,
@@ -6783,7 +6783,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "fhY" = (
 /obj/machinery/door/unpowered/wooddoor,
@@ -6831,7 +6831,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "flU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7528,7 +7528,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "gls" = (
 /obj/structure/table/wood,
@@ -7808,7 +7808,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/powerplant)
 "gKn" = (
 /obj/item/shard,
@@ -7911,7 +7911,7 @@
 /area/f13/sunny_dale)
 "gSu" = (
 /obj/structure/railing,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "gTi" = (
 /obj/structure/table/wood,
@@ -8635,14 +8635,14 @@
 /area/f13/sunny_dale)
 "hTz" = (
 /obj/structure/railing/corner,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "hUP" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "hUT" = (
 /obj/item/broken_bottle,
@@ -8801,7 +8801,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "igc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8927,7 +8927,7 @@
 "isp" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter,
 /obj/structure/railing/corner,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/powerplant)
 "isR" = (
 /obj/structure/chair/f13/metal/broken,
@@ -9106,7 +9106,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "iHi" = (
 /obj/structure/closet,
@@ -10705,7 +10705,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "kZq" = (
 /turf/open/floor/plasteel/f13/purple/side/dirty,
@@ -10825,7 +10825,7 @@
 	},
 /obj/structure/railing,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "lgJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10868,7 +10868,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "lhP" = (
 /obj/item/sign{
@@ -11041,7 +11041,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "lpV" = (
 /obj/structure/closet/cardboard,
@@ -11375,7 +11375,7 @@
 "lRI" = (
 /obj/structure/railing/corner,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "lSg" = (
 /obj/machinery/light{
@@ -11544,7 +11544,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "mds" = (
 /obj/structure/closet/cabinet,
@@ -12250,7 +12250,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "neB" = (
 /obj/structure/barricade/wooden,
@@ -12281,7 +12281,7 @@
 /area/f13/powerplant)
 "ngK" = (
 /obj/structure/lattice/catwalk,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "nho" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
@@ -12299,7 +12299,7 @@
 /area/f13/powerplant)
 "njl" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "njD" = (
 /obj/structure/table/low_wall/wood,
@@ -12937,7 +12937,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "obH" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
@@ -13099,7 +13099,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "ooS" = (
 /obj/effect/decal/cleanable/blood/splatter{
@@ -13146,7 +13146,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "osI" = (
 /obj/structure/rack,
@@ -13194,7 +13194,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "owQ" = (
 /obj/structure/toilet,
@@ -13252,7 +13252,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "oAr" = (
 /obj/effect/decal/cleanable/crayon{
@@ -13443,7 +13443,7 @@
 /obj/machinery/light/dim{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/powerplant)
 "oKV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13455,7 +13455,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "oMM" = (
 /turf/open/floor/plasteel/f13/blue/corner/dirty,
@@ -13588,7 +13588,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "oVx" = (
 /obj/machinery/computer/arcade/battle{
@@ -13694,7 +13694,7 @@
 "peq" = (
 /obj/structure/ladder,
 /obj/structure/lattice/catwalk,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "peH" = (
 /obj/structure/table/wood,
@@ -13743,7 +13743,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "phD" = (
 /obj/structure/rack,
@@ -13856,7 +13856,7 @@
 /area/f13/sunny_dale)
 "pmT" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/powerplant)
 "pob" = (
 /obj/machinery/iv_drip,
@@ -14806,7 +14806,7 @@
 	dir = 10
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "qGK" = (
 /turf/open/floor/plasteel/f13/blue,
@@ -14905,7 +14905,7 @@
 "qPK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "qPM" = (
 /turf/closed/wall/r_wall/f13/metal/rust,
@@ -15173,7 +15173,7 @@
 	dir = 1
 	},
 /obj/structure/railing,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "rgO" = (
 /obj/item/flashlight/lantern{
@@ -15321,7 +15321,7 @@
 "rrL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "rrS" = (
 /obj/structure/fence/fencecorner{
@@ -15957,7 +15957,7 @@
 "soN" = (
 /obj/structure/railing,
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "spa" = (
 /obj/structure/bookcase/random/reference{
@@ -16009,7 +16009,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "sqz" = (
 /obj/machinery/door/unpowered/wooddoor,
@@ -16240,7 +16240,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/powerplant)
 "sJE" = (
 /obj/machinery/light{
@@ -16262,7 +16262,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "sLB" = (
 /obj/structure/sign/poster/contraband/c20r,
@@ -16427,7 +16427,7 @@
 /area/f13/sunny_dale)
 "sTL" = (
 /obj/machinery/light/small,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "sUj" = (
 /turf/open/floor/plasteel/f13/misc/medical,
@@ -16510,14 +16510,14 @@
 /turf/open/floor/wood/f13,
 /area/f13/sunny_dale)
 "taz" = (
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/cave)
 "taV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/underground/bos)
 "taW" = (
 /obj/structure/table,
@@ -17105,7 +17105,7 @@
 /area/f13/sunny_dale)
 "tLe" = (
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/ncr_main)
 "tMk" = (
 /obj/structure/table/low_wall/brick,
@@ -17415,7 +17415,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/wood,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/sunny_dale)
 "uiu" = (
 /obj/structure/chair/comfy/f13/retro{
@@ -17822,7 +17822,7 @@
 "uXb" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "uXz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17967,7 +17967,7 @@
 "vkm" = (
 /obj/machinery/light/small,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "vkw" = (
 /turf/open/floor/plasteel/f13/white/dirty,
@@ -18969,7 +18969,7 @@
 /obj/structure/chair/f13/metal{
 	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13)
 "wLS" = (
 /obj/structure/stairs{
@@ -19169,7 +19169,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "xbO" = (
 /obj/effect/decal/cleanable/glass,
@@ -19470,7 +19470,7 @@
 "xwS" = (
 /obj/structure/railing,
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "xxB" = (
 /obj/structure/sink{
@@ -19752,7 +19752,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/sunlight/roofSetter/mountain,
-/turf/open/transparent/openspace,
+/turf/open/transparent/openspace/f13_no_build,
 /area/f13/klamat)
 "xSs" = (
 /obj/structure/barricade/wooden,

--- a/fallout/turfs/plating.dm
+++ b/fallout/turfs/plating.dm
@@ -393,3 +393,8 @@
 	desc = "A segment of broken ice."
 	icon = 'fallout/icons/turf/ice.dmi'
 	icon_state = "chunk"
+
+//This functions like normal openspace but prevents placing lattice, so people cannot cheese catwalks or floors clear across the map.
+//TODO: give unique icon_state/color to make it visually distinct from regular openspace.
+/turf/open/transparent/openspace/f13_no_build
+	can_build_on = FALSE


### PR DESCRIPTION
## About The Pull Request

This creates `/turf/open/transparent/openspace/f13_no_build`, identical to regular openspace in every way except that players are unable to use metal rods on it to build lattice, making it impossible to cheese your way across the map with huge stretches of catwalk or floors. This PR also changes all openspace on Mammoth to this child type.

Mappers are able to specify specific areas where player **can** still build, simply by using regular old `/turf/open/transparent/openspace`.

To do eventually or something: give this a unique icon so it's not the same as regular open space.

## Why It's Good For The Game

Self-explanatory, needed prior to public testing.