### PR TITLE
A few fixes to turfs.

### DIFF
--- a/_maps/mammoth.json
+++ b/_maps/mammoth.json
@@ -18,7 +18,7 @@
 		{
 			"Up": 1,
 			"Down": -1,
-			"Baseturf": "/turf/open/transparent/openspace",
+			"Baseturf": "/turf/open/floor/plating/ground/mountain",
 			"Linkage": "Cross",
 			"Gravity": true
 		},

--- a/fallout/turfs/f13_floors.dm
+++ b/fallout/turfs/f13_floors.dm
@@ -10,6 +10,15 @@
 	if(icon_state == "housewood1")
 		icon_state = "housewood[rand(1,3)]" //This automatically gives wooden floors a nice varied pattern.
 
+/turf/open/floor/wood/f13/burn_tile()
+	burnt = 1
+	return //We lack sprites for this. To do: make overlay here instead.
+
+/turf/open/floor/wood/f13/break_tile()
+	broken = 1
+	return
+
+
 /turf/open/floor/wood/f13/broken
 	icon_state = "housebase"
 	desc = "Rotting wooden flooring."
@@ -89,7 +98,7 @@
 
 //Plasteel (generic) floor tiles.
 
-/obj/item/stack/tile/plasteel/f13
+/obj/item/stack/tile/plasteel/f13 //We need this because upstream turf code is not great.
 	turf_type = /turf/open/floor/plasteel/f13
 
 
@@ -97,6 +106,16 @@
 	icon = 'fallout/icons/turf/floors_2.dmi'
 	icon_state = "floor"
 	floor_tile = /obj/item/stack/tile/plasteel/f13
+
+
+/turf/open/floor/plasteel/f13/burn_tile()
+	burnt = 1
+	return //We're not spriting damage variations for the millions of tiles we have. To do: make overlay here instead.
+
+/turf/open/floor/plasteel/f13/break_tile()
+	broken = 1
+	return
+
 
 /turf/open/floor/plasteel/f13/_dirty
 	icon = 'fallout/icons/turf/floors_2.dmi'

--- a/fallout/turfs/f13_floors.dm
+++ b/fallout/turfs/f13_floors.dm
@@ -89,10 +89,14 @@
 
 //Plasteel (generic) floor tiles.
 
+/obj/item/stack/tile/plasteel/f13
+	turf_type = /turf/open/floor/plasteel/f13
+
 
 /turf/open/floor/plasteel/f13
 	icon = 'fallout/icons/turf/floors_2.dmi'
 	icon_state = "floor"
+	floor_tile = /obj/item/stack/tile/plasteel/f13
 
 /turf/open/floor/plasteel/f13/_dirty
 	icon = 'fallout/icons/turf/floors_2.dmi'


### PR DESCRIPTION
## About The Pull Request

Fixes:
https://github.com/Mojave-Sun/tg-ashcloud/issues/94
https://github.com/Mojave-Sun/tg-ashcloud/issues/90

Previously prying up tiles and replacing them lead to an error from a mismatched `icon` var due to shitty turf code from upstream. This solves that by creating a /f13 tile **item**, but unfortunately leaves us where old Fallout 13 was; with no way for players to replace the exact floor tile type they pried up. I will work on that part of the problem again in the future.

This also solves explosions causing missing icon_states because we don't have the icon_ states needed for it and we have no chance of ever making that many..
Currently it just disables any visual cue of a tile being damaged, but I'm hoping to stick an overlay in here instead soon, possibly before this PR gets merged.

Lastly, destroyed turfs on the ground floor now create mountain floor, instead of openspace.
...Not really sure why we ever thought that was a good idea.

## Why It's Good For The Game

Needed to take care of these before we do a public test.
