### PR TITLE
Add .dmm merge driver

### DIFF
--- a/tools/hooks/dmm.merge
+++ b/tools/hooks/dmm.merge
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tools/hooks/python.sh -m merge_driver_dmm "$@"

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -43,6 +43,20 @@ class DMM:
             f.flush()
             return bio.getvalue()
 
+    def get_or_generate_key(self, tile):
+        try:
+            return self.dictionary.inv[tile]
+        except KeyError:
+            key = self.generate_new_key()
+            self.dictionary[key] = tile
+            return key
+
+    def get_tile(self, coord):
+        return self.dictionary[self.grid[coord]]
+
+    def set_tile(self, coord, tile):
+        self.grid[coord] = self.get_or_generate_key(tile)
+
     def generate_new_key(self):
         free_keys = self._ensure_free_keys(1)
         # choose one of the free keys at random

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -244,10 +244,8 @@ def is_bad_atom_ordering(key, atoms):
         print(f"Warning: key '{key}' is missing either a turf or area")
     return can_fix
 
-def fix_atom_ordering(atoms):
-    movables = []
-    turfs = []
-    areas = []
+def split_atom_groups(atoms):
+    movables, turfs, areas = [], [], []
     for each in atoms:
         if each.startswith('/turf'):
             turfs.append(each)
@@ -255,6 +253,10 @@ def fix_atom_ordering(atoms):
             areas.append(each)
         else:
             movables.append(each)
+    return movables, turfs, areas
+
+def fix_atom_ordering(atoms):
+    movables, turfs, areas = split_atom_groups(atoms)
     movables.extend(turfs)
     movables.extend(areas)
     return movables

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -139,6 +139,9 @@ class DMM:
             for x in range(1, self.size.x + 1):
                 yield (y, x)
 
+    def __repr__(self):
+        return f"DMM(size={self.size}, key_length={self.key_length}, dictionary_size={len(self.dictionary)})"
+
 # ----------
 # key handling
 
@@ -301,7 +304,7 @@ def save_tgm(dmm, output):
         output.write("\n")
         for x in range(1, max_x + 1):
             output.write(f"({x},{1},{z}) = {{\"\n")
-            for y in range(1, max_y + 1):
+            for y in range(max_y, 0, -1):
                 output.write(f"{num_to_key(dmm.grid[x, y, z], dmm.key_length)}\n")
             output.write("\"}\n")
 
@@ -323,7 +326,7 @@ def save_dmm(dmm, output):
     for z in range(1, max_z + 1):
         output.write(f"(1,1,{z}) = {{\"\n")
 
-        for y in range(1, max_y + 1):
+        for y in range(max_y, 0, -1):
             for x in range(1, max_x + 1):
                 try:
                     output.write(num_to_key(dmm.grid[x, y, z], dmm.key_length))
@@ -556,7 +559,12 @@ def _parse(map_raw_text):
     if curr_y > maxy:
         maxy = curr_y
 
+    # Convert from raw .dmm coordinates to DM/BYOND coordinates by flipping Y
+    grid2 = dict()
+    for (x, y, z), tile in grid.items():
+        grid2[x, maxy + 1 - y, z] = tile
+
     data = DMM(key_length, Coordinate(maxx, maxy, maxz))
     data.dictionary = dictionary
-    data.grid = grid
+    data.grid = grid2
     return data

--- a/tools/mapmerge2/merge_driver_dmm.py
+++ b/tools/mapmerge2/merge_driver_dmm.py
@@ -3,6 +3,20 @@ import sys
 import dmm
 import mapmerge
 
+def select(base, left, right):
+    if left == right:
+        # whether or not it's in the base, both sides agree
+        return left
+    elif base == left:
+        # base == left, but right is different: accept right
+        return right
+    elif base == right:
+        # base == right, but left is different: accept left
+        return left
+    else:
+        # all three versions are different
+        return None
+
 def three_way_merge(base, left, right):
     if base.size != left.size or base.size != right.size:
         print("Dimensions have changed:")
@@ -21,26 +35,24 @@ def three_way_merge(base, left, right):
         left_tile = left.get_tile(coord)
         right_tile = right.get_tile(coord)
 
-        if left_tile == right_tile:
-            # whether or not it's in the base, both sides agree
-            merged.set_tile(coord, left_tile)
-        elif base_tile == left_tile:
-            # base == left, but right is different: accept right
-            merged.set_tile(coord, right_tile)
-        elif base_tile == right_tile:
-            # base == right, but left is different: accept left
-            merged.set_tile(coord, left_tile)
-        else:
-            # all three versions are different
-            trouble = True
-            print(f" C: Both sides touch the tile at {coord}")
-            merged.set_tile(coord, left_tile + right_tile)
+        # try to merge the whole tiles
+        whole_tile_merge = select(base_tile, left_tile, right_tile)
+        if whole_tile_merge is not None:
+            merged.set_tile(coord, whole_tile_merge)
+            continue
+
+        # TODO: try other strategies here
+
+        # fall back to requiring manual conflict resolution
+        trouble = True
+        print(f" C: Both sides touch the tile at {coord}")
+        merged.set_tile(coord, left_tile + right_tile)
 
     merged = mapmerge.merge_map(merged, base)
     return trouble, merged
 
 def main(path, original, left, right):
-    print(f"Resolving merge conflicts: {path}")
+    print(f"Merging map: {path}")
 
     map_orig = dmm.DMM.from_file(original)
     map_left = dmm.DMM.from_file(left)

--- a/tools/mapmerge2/merge_driver_dmm.py
+++ b/tools/mapmerge2/merge_driver_dmm.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import sys
+import dmm
+import mapmerge
+
+def three_way_merge(base, left, right):
+    if base.size != left.size or base.size != right.size:
+        print("Dimensions have changed:")
+        print(f"    Base: {base.size}")
+        print(f"    Ours: {left.size}")
+        print(f"    Theirs: {right.size}")
+        return True, None
+
+    trouble = False
+    merged = dmm.DMM(base.key_length, base.size)
+    merged.dictionary = base.dictionary.copy()
+
+    for (z, y, x) in base.coords_zyx:
+        coord = x, y, z
+        base_tile = base.get_tile(coord)
+        left_tile = left.get_tile(coord)
+        right_tile = right.get_tile(coord)
+
+        if left_tile == right_tile:
+            # whether or not it's in the base, both sides agree
+            merged.set_tile(coord, left_tile)
+        elif base_tile == left_tile:
+            # base == left, but right is different: accept right
+            merged.set_tile(coord, right_tile)
+        elif base_tile == right_tile:
+            # base == right, but left is different: accept left
+            merged.set_tile(coord, left_tile)
+        else:
+            # all three versions are different
+            trouble = True
+            print(f" C: Both sides touch the tile at {coord}")
+            merged.set_tile(coord, left_tile + right_tile)
+
+    merged = mapmerge.merge_map(merged, base)
+    return trouble, merged
+
+def main(path, original, left, right):
+    print(f"Resolving merge conflicts: {path}")
+
+    map_orig = dmm.DMM.from_file(original)
+    map_left = dmm.DMM.from_file(left)
+    map_right = dmm.DMM.from_file(right)
+
+    trouble, merged = three_way_merge(map_orig, map_left, map_right)
+    if merged:
+        merged.to_file(left)
+    if trouble:
+        print("!!! Manual merge required!")
+        if merged:
+            print("    A best-effort merge was performed. You must edit the map and remove all")
+            print("    /obj/effect/mapping_helpers/conflict.")
+        else:
+            print("    The map was totally unable to be merged, you must start with one version")
+            print("    or the other and manually resolve the conflict.")
+        print("    Information about which tiles conflicted is listed above.")
+    return trouble
+
+if __name__ == '__main__':
+    if len(sys.argv) != 6:
+        print("DMM merge driver called with wrong number of arguments")
+        print("    usage: merge-driver-dmm %P %O %A %B %L")
+        exit(1)
+
+    # "left" is also the file that ought to be overwritten
+    _, path, original, left, right, conflict_size_marker = sys.argv
+    exit(main(path, original, left, right))


### PR DESCRIPTION
This is a work-in-progress/experimental [merge driver](https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver) with the goal of automatically resolving map conflicts, and when that isn't possible, producing a valid `.dmm` file so conflicts can be manually resolved in a map editor instead of a text editor.

It is installed the same way as the existing precommit hook (run `tools/hooks/install.bat` or `tools/hooks/install.sh`) and runs automatically upon `git merge`.

I will be lurking in your Discord; ping me if you have trouble using this tool. I hope that your feedback can be used to improve it and it can benefit the community at large.