### PR TITLE
Whoops! Adds the Nurse to the Job landmarks and removes Shopkeep.

### DIFF
--- a/mojave/effects/landmarks.dm
+++ b/mojave/effects/landmarks.dm
@@ -19,9 +19,6 @@
 /obj/effect/landmark/start/ms13/settler
 	name = "Settler"
 
-/obj/effect/landmark/start/ms13/shopkeep
-	name = "Shopkeep"
-
 /obj/effect/landmark/start/ms13/bartender
 	name = "Bartender"
 
@@ -30,6 +27,9 @@
 
 /obj/effect/landmark/start/ms13/doctor
 	name = "Doctor"
+
+/obj/effect/landmark/start/ms13/nurse
+	name = "Nurse"
 
 /obj/effect/landmark/start/ms13/deputy
 	name = "Deputy"


### PR DESCRIPTION
I had forgot to fix this previously. The only thing changed in this is the removal of the Shopkeeper's landmark and the addition of the Nurse landmark.