### PR TITLE
THE GREAT RADIO REWORK

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -395,17 +395,6 @@
 				/obj/item/organ/ears/cat = 1)
 	category = CAT_CLOTHING
 
-
-/datum/crafting_recipe/radiogloves
-	name = "Radio Gloves"
-	result = /obj/item/clothing/gloves/radio
-	time = 15
-	reqs = list(/obj/item/clothing/gloves/color/black = 1,
-				/obj/item/stack/cable_coil = 2,
-				/obj/item/radio = 1)
-	tools = list(TOOL_WIRECUTTER)
-	category = CAT_CLOTHING
-
 /datum/crafting_recipe/mixedbouquet
 	name = "Mixed bouquet"
 	result = /obj/item/bouquet
@@ -931,4 +920,37 @@
 				/obj/item/grenade/gas_crystal/proto_nitrate_crystal = 1,
 				/obj/item/grenade/gas_crystal/zauker_crystal = 1
 				)
+	category = CAT_MISC
+
+/datum/crafting_recipe/radio
+	name = "handheld radio"
+	result = /obj/item/radio/ms13
+	time = 15
+	reqs = list(/obj/item/stack/cable_coil = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER)
+	category = CAT_MISC
+
+/datum/crafting_recipe/hamradio
+	name = "ham radio"
+	result = /obj/item/radio/ms13/ham
+	time = 15
+	reqs = list(/obj/item/stack/cable_coil = 3,
+				/obj/item/stack/sheet/metal = 5,
+				/obj/item/stack/sheet/mineral/wood = 10)
+	tools = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER)
+	category = CAT_MISC
+
+/datum/crafting_recipe/broadcastradio
+	name = "broadcast hand radio"
+	result = /obj/item/radio/ms13/broadcast
+	time = 15
+	reqs = list(/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/sheet/metal = 10,
+				/obj/item/stock_parts/capacitor = 1,
+				/obj/item/stock_parts/cell = 1,
+				/obj/item/stack/sheet/plasteel = 3,
+				/obj/item/assembly/igniter = 1,
+				/obj/item/radio/ms13 = 1)
+	tools = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER, TOOL_WELDER)
 	category = CAT_MISC

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -394,6 +394,19 @@
 	reqs = list(/obj/item/organ/tail/cat = 1,
 				/obj/item/organ/ears/cat = 1)
 	category = CAT_CLOTHING
+/*MOJAVE SUN EDIT BEGIN
+
+/datum/crafting_recipe/radiogloves
+	name = "Radio Gloves"
+	result = /obj/item/clothing/gloves/radio
+	time = 15
+	reqs = list(/obj/item/clothing/gloves/color/black = 1,
+				/obj/item/stack/cable_coil = 2,
+				/obj/item/radio = 1)
+	tools = list(TOOL_WIRECUTTER)
+	category = CAT_CLOTHING
+
+MOJAVE SUN EDIT END*/
 
 /datum/crafting_recipe/mixedbouquet
 	name = "Mixed bouquet"
@@ -922,35 +935,3 @@
 				)
 	category = CAT_MISC
 
-/datum/crafting_recipe/radio
-	name = "handheld radio"
-	result = /obj/item/radio/ms13
-	time = 15
-	reqs = list(/obj/item/stack/cable_coil = 2,
-				/obj/item/stack/sheet/metal = 5)
-	tools = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER)
-	category = CAT_MISC
-
-/datum/crafting_recipe/hamradio
-	name = "ham radio"
-	result = /obj/item/radio/ms13/ham
-	time = 15
-	reqs = list(/obj/item/stack/cable_coil = 3,
-				/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/mineral/wood = 10)
-	tools = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER)
-	category = CAT_MISC
-
-/datum/crafting_recipe/broadcastradio
-	name = "broadcast hand radio"
-	result = /obj/item/radio/ms13/broadcast
-	time = 15
-	reqs = list(/obj/item/stack/cable_coil = 5,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stock_parts/capacitor = 1,
-				/obj/item/stock_parts/cell = 1,
-				/obj/item/stack/sheet/plasteel = 3,
-				/obj/item/assembly/igniter = 1,
-				/obj/item/radio/ms13 = 1)
-	tools = list(TOOL_WIRECUTTER, TOOL_SCREWDRIVER, TOOL_WELDER)
-	category = CAT_MISC

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -32,7 +32,10 @@
 	var/freqlock = FALSE  // Frequency lock to stop the user from untuning specialist radios.
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
 	var/command = FALSE  // If true, use_command can be toggled at will.
+
+	//Mojave Sun broadcast variable
 	var/radio_broadcast = 1 //determines how badly a broadcasting radio suffers from interference. Goes from 1 to 3, higher is better.
+
 	///makes anyone who is talking through this anonymous.
 	var/anonymize = FALSE
 
@@ -209,6 +212,7 @@
 			if(length(empty_indexes) == 1)
 				message = stars(message)
 
+//Start of Mojave Sun edit
 	if (radio_broadcast >= 0)
 		if (radio_broadcast == 0)
 			return FALSE
@@ -218,7 +222,7 @@
 			message = stars(message, 7)
 		if (radio_broadcast == 3)
 			message = stars(message, 1)
-
+//End of Mojave Sun edit
 	if(!spans)
 		spans = list(M.speech_span)
 	if(!language)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -39,7 +39,7 @@
 	var/command = FALSE  // If true, use_command can be toggled at will.
 
 	//Mojave Sun broadcast variable
-	var/radio_broadcast = RADIOSTATIC_HEAVY //determines how badly a broadcasting radio suffers from static. The defines are at the top.
+	var/radio_broadcast = FALSE //determines how badly a broadcasting radio suffers from static. The defines are at the top.
 	//The number refers to the odds that each character in a message is replaced with a star.
 
 
@@ -178,9 +178,19 @@
 		if("listen")
 			listening = !listening
 			. = TRUE
+		/*
 		if("broadcast")
 			broadcasting = !broadcasting
 			. = TRUE
+		*/
+		//original broadcast handling code
+
+		if("broadcast") //MOJAVE SUN EDIT START
+			if (radio_broadcast == FALSE)
+				. = FALSE
+			else
+				broadcasting = !broadcasting
+				. = TRUE // MOJAVE SUN EDIT END
 		if("channel")
 			var/channel = params["channel"]
 			if(!(channel in channels))
@@ -221,7 +231,10 @@
 
 //Start of Mojave Sun edit
 	if (radio_broadcast)
-		message = stars(message, radio_broadcast)
+		if (radio_broadcast == FALSE)
+			return FALSE
+		if (radio_broadcast > 0)
+			message = stars(message, radio_broadcast)
 
 //End of Mojave Sun edit
 	if(!spans)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,4 +1,9 @@
 #define FREQ_LISTENING (1<<0)
+//Mojave Sun static defines
+#define RADIOSATTIC_LIGHT 1
+#define RADIOSTATIC_MEDIUM 10
+#define RADIOSTATIC_HEAVY 16
+//end of Mojave Sun defines
 
 /obj/item/radio
 	icon = 'icons/obj/radio.dmi'
@@ -34,7 +39,9 @@
 	var/command = FALSE  // If true, use_command can be toggled at will.
 
 	//Mojave Sun broadcast variable
-	var/radio_broadcast = 1 //determines how badly a broadcasting radio suffers from interference. Goes from 1 to 3, higher is better.
+	var/radio_broadcast = RADIOSTATIC_HEAVY //determines how badly a broadcasting radio suffers from static. The defines are at the top.
+	//The number refers to the odds that each character in a message is replaced with a star.
+
 
 	///makes anyone who is talking through this anonymous.
 	var/anonymize = FALSE
@@ -213,15 +220,9 @@
 				message = stars(message)
 
 //Start of Mojave Sun edit
-	if (radio_broadcast >= 0)
-		if (radio_broadcast == 0)
-			return FALSE
-		if (radio_broadcast == 1)
-			message = stars(message, 14)
-		if (radio_broadcast == 2)
-			message = stars(message, 7)
-		if (radio_broadcast == 3)
-			message = stars(message, 1)
+	if (radio_broadcast)
+		message = stars(message, radio_broadcast)
+
 //End of Mojave Sun edit
 	if(!spans)
 		spans = list(M.speech_span)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -32,7 +32,7 @@
 	var/freqlock = FALSE  // Frequency lock to stop the user from untuning specialist radios.
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
 	var/command = FALSE  // If true, use_command can be toggled at will.
-	var/radio_broadcast = 3 //determines how badly a broadcasting radio suffers from interference. Goes from 1 to 3, higher is better.
+	var/radio_broadcast = 1 //determines how badly a broadcasting radio suffers from interference. Goes from 1 to 3, higher is better.
 	///makes anyone who is talking through this anonymous.
 	var/anonymize = FALSE
 
@@ -207,7 +207,7 @@
 			if(HAS_TRAIT(mute, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(mute, TRAIT_EMOTEMUTE))
 				return FALSE
 			if(length(empty_indexes) == 1)
-					message = stars(message)
+				message = stars(message)
 
 	if (radio_broadcast >= 0)
 		if (radio_broadcast == 0)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -206,14 +206,14 @@
 				return FALSE
 			if(HAS_TRAIT(mute, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(mute, TRAIT_EMOTEMUTE))
 				return FALSE
-				if(length(empty_indexes) == 1)
+			if(length(empty_indexes) == 1)
 					message = stars(message)
 
 	if (radio_broadcast >= 0)
 		if (radio_broadcast == 0)
 			return FALSE
 		if (radio_broadcast == 1)
-			message = stars(message, 12)
+			message = stars(message, 14)
 		if (radio_broadcast == 2)
 			message = stars(message, 7)
 		if (radio_broadcast == 3)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,6 +1,6 @@
 #define FREQ_LISTENING (1<<0)
 //Mojave Sun static defines
-#define RADIOSATTIC_LIGHT 1
+#define RADIOSTATIC_LIGHT 1
 #define RADIOSTATIC_MEDIUM 10
 #define RADIOSTATIC_HEAVY 16
 //end of Mojave Sun defines

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -32,7 +32,7 @@
 	var/freqlock = FALSE  // Frequency lock to stop the user from untuning specialist radios.
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
 	var/command = FALSE  // If true, use_command can be toggled at will.
-
+	var/radio_broadcast = 3 //determines how badly a broadcasting radio suffers from interference. Goes from 1 to 3, higher is better.
 	///makes anyone who is talking through this anonymous.
 	var/anonymize = FALSE
 
@@ -43,6 +43,9 @@
 	var/syndie = FALSE  // If true, hears all well-known channels automatically, and can say/hear on the Syndicate channel.
 	var/list/channels = list()  // Map from name (see communications.dm) to on/off. First entry is current department (:h)
 	var/list/secure_radio_connections
+
+
+
 
 /obj/item/radio/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] starts bouncing [src] off [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -197,14 +200,25 @@
 			var/obj/item/clothing/gloves/radio/G = mute.get_item_by_slot(ITEM_SLOT_GLOVES)
 			if(!istype(G))
 				return FALSE
-			if(length(empty_indexes) == 1)
-				message = stars(message)
 			if(length(empty_indexes) == 0) //Due to the requirement of gloves, the arm check for normal speech would be redundant here.
 				return FALSE
 			if(mute.handcuffed)//Would be weird if they couldn't sign but their words still went over the radio
 				return FALSE
 			if(HAS_TRAIT(mute, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(mute, TRAIT_EMOTEMUTE))
 				return FALSE
+				if(length(empty_indexes) == 1)
+					message = stars(message)
+
+	if (radio_broadcast >= 0)
+		if (radio_broadcast == 0)
+			return FALSE
+		if (radio_broadcast == 1)
+			message = stars(message, 12)
+		if (radio_broadcast == 2)
+			message = stars(message, 7)
+		if (radio_broadcast == 3)
+			message = stars(message, 1)
+
 	if(!spans)
 		spans = list(M.speech_span)
 	if(!language)
@@ -267,6 +281,9 @@
 		signal.levels = list(0)  // reaches all Z-levels
 		signal.broadcast()
 		return
+
+	//adds radio interference
+
 
 	// All radios make an attempt to use the subspace system first
 	signal.send_to_receivers()

--- a/mojave/items/misc/radios.dm
+++ b/mojave/items/misc/radios.dm
@@ -1,13 +1,50 @@
+/obj/item/radio/ms13
+	icon = 'mojave/icons/objects/hamradio.dmi'
+	name = "hand Radio"
+	icon_state = "handradio"
+	inhand_icon_state = "handradio_"
+	desc = "A basic handheld radio that recieves over a relatively long range, unfortunately this one can't broadcast."
+
+	w_class = WEIGHT_CLASS_SMALL
+	custom_materials = list(/datum/material/iron=75, /datum/material/glass=25)
+	radio_broadcast = 0
+
+/obj/item/radio/ms13/can_receive(freq, level, AIuser)
+	if(ishuman(src.loc))
+		var/mob/living/carbon/human/H = src.loc
+		if(H.is_holding(src))
+			return ..(freq, level)
+	else if(AIuser)
+		return ..(freq, level)
+	return FALSE
+
+/obj/item/radio/ms13/broadcast
+	icon = 'mojave/icons/objects/hamradio.dmi'
+	name = "broadcast hand radio"
+	icon_state = "handradio"
+	inhand_icon_state = "handradio_"
+	desc = "A rare handheld radio that can send as well as recieve signals. The poor quality of broadcasts makes it unpleasent to listen to, and doing so too often is a good way to get lynched."
+	radio_broadcast = 1
+
+/obj/item/radio/ms13/broadcast/prewar
+	icon = 'mojave/icons/objects/hamradio.dmi'
+	name = "pre-War hand radio"
+	icon_state = "handradio"
+	inhand_icon_state = "handradio_"
+	desc = "The best a handheld gets, this extremely rare radio can broadcast at reasonably high quality while remaining lightweight and portable."
+	radio_broadcast = 2
+
 /obj/item/radio/ms13/ham
 	name = "ham radio"
-	desc = "An amateur radio setup. The sound quality could be better, but it's better than screaming into the horizon."
+	desc = "An amateur radio setup. The sound quality could be better, but it beats listening to brahmin all day."
 	icon = 'mojave/icons/objects/hamradio.dmi'
 	icon_state = "radio_on"
-	canhear_range = 1
+	canhear_range = 7
 	pixel_y = 5
 	freerange = TRUE
 	anonymize = TRUE
 	anchored = TRUE
+	radio_broadcast = 0
 
 /obj/item/radio/ms13/ham/Initialize(mapload, ndir, building)
 	. = ..()
@@ -17,11 +54,33 @@
 	if(!current_area)
 		return
 	RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, .proc/AreaPowerCheck)
+/obj/item/radio/ms13/ham/broadcast
+	name = "broadcast ham radio"
+	desc = "An amateur radio setup. This one is set up to broadcast over local frequencies."
+	icon = 'mojave/icons/objects/hamradio.dmi'
+	icon_state = "radio_on"
+	canhear_range = 7
+	pixel_y = 5
+	freerange = TRUE
+	anonymize = TRUE
+	anchored = TRUE
+	radio_broadcast = 2
 
-/obj/item/radio/ms13/ham/examine(mob/user)
+/obj/item/radio/ms13/ham/broadcast/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Use [MODE_TOKEN_INTERCOM] when nearby to speak into it.</span>"
 
+/obj/item/radio/ms13/ham/broadcast
+	name = "high power broadcasting set"
+	desc = "A high end broadcasting set used by professional radio studios. Legend has it that Mr. New Vegas himself uses this model."
+	icon = 'mojave/icons/objects/hamradio.dmi'
+	icon_state = "radio_on"
+	canhear_range = 7
+	pixel_y = 5
+	freerange = TRUE
+	anonymize = TRUE
+	anchored = TRUE
+	radio_broadcast = 3
 /**
  * Override attack_tk_grab instead of attack_tk because we actually want attack_tk's
  * functionality. What we DON'T want is attack_tk_grab attempting to pick up the
@@ -92,3 +151,4 @@
 	else
 		on = current_area.powered(AREA_USAGE_EQUIP) // set "on" to the equipment power status of our area.
 	update_icon()
+

--- a/mojave/items/misc/radios.dm
+++ b/mojave/items/misc/radios.dm
@@ -36,27 +36,7 @@
 
 /obj/item/radio/ms13/ham
 	name = "ham radio"
-	desc = "An amateur radio setup. The sound quality could be better, but it beats listening to brahmin all day."
-	icon = 'mojave/icons/objects/hamradio.dmi'
-	icon_state = "radio_on"
-	canhear_range = 7
-	pixel_y = 5
-	freerange = TRUE
-	anonymize = TRUE
-	anchored = TRUE
-	radio_broadcast = FALSE
-
-/obj/item/radio/ms13/ham/Initialize(mapload, ndir, building)
-	. = ..()
-	if(building)
-		setDir(ndir)
-	var/area/current_area = get_area(src)
-	if(!current_area)
-		return
-	RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, .proc/AreaPowerCheck)
-/obj/item/radio/ms13/ham/broadcast
-	name = "broadcast ham radio"
-	desc = "An amateur radio setup. This one is set up to broadcast over local frequencies."
+	desc = "An amateur radio setup. The sound quality could be better, but it beats listening to brahmin all day. Has a working microphone, though the quality isn't great."
 	icon = 'mojave/icons/objects/hamradio.dmi'
 	icon_state = "radio_on"
 	canhear_range = 7
@@ -66,9 +46,18 @@
 	anchored = TRUE
 	radio_broadcast = RADIOSTATIC_MEDIUM
 
-/obj/item/radio/ms13/ham/broadcast/examine(mob/user)
+/obj/item/radio/ms13/ham/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Use [MODE_TOKEN_INTERCOM] when nearby to speak into it.</span>"
+
+/obj/item/radio/ms13/ham/Initialize(mapload, ndir, building)
+	. = ..()
+	if(building)
+		setDir(ndir)
+	var/area/current_area = get_area(src)
+	if(!current_area)
+		return
+	RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, .proc/AreaPowerCheck)
 
 /obj/item/radio/ms13/ham/broadcast
 	name = "high power broadcasting set"

--- a/mojave/items/misc/radios.dm
+++ b/mojave/items/misc/radios.dm
@@ -80,7 +80,7 @@
 	freerange = TRUE
 	anonymize = TRUE
 	anchored = TRUE
-	radio_broadcast = RADIOSATTIC_LIGHT
+	radio_broadcast = RADIOSTATIC_LIGHT
 /**
  * Override attack_tk_grab instead of attack_tk because we actually want attack_tk's
  * functionality. What we DON'T want is attack_tk_grab attempting to pick up the

--- a/mojave/items/misc/radios.dm
+++ b/mojave/items/misc/radios.dm
@@ -7,7 +7,7 @@
 
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=75, /datum/material/glass=25)
-	radio_broadcast = 0
+	radio_broadcast = FALSE
 
 /obj/item/radio/ms13/can_receive(freq, level, AIuser)
 	if(ishuman(src.loc))
@@ -24,7 +24,7 @@
 	icon_state = "handradio"
 	inhand_icon_state = "handradio_"
 	desc = "A rare handheld radio that can send as well as recieve signals. The poor quality of broadcasts makes it unpleasent to listen to, and doing so too often is a good way to get lynched."
-	radio_broadcast = 1
+	radio_broadcast = RADIOSTATIC_HEAVY
 
 /obj/item/radio/ms13/broadcast/prewar
 	icon = 'mojave/icons/objects/hamradio.dmi'
@@ -32,7 +32,7 @@
 	icon_state = "handradio"
 	inhand_icon_state = "handradio_"
 	desc = "The best a handheld gets, this extremely rare radio can broadcast at reasonably high quality while remaining lightweight and portable."
-	radio_broadcast = 2
+	radio_broadcast = RADIOSTATIC_MEDIUM
 
 /obj/item/radio/ms13/ham
 	name = "ham radio"
@@ -44,7 +44,7 @@
 	freerange = TRUE
 	anonymize = TRUE
 	anchored = TRUE
-	radio_broadcast = 0
+	radio_broadcast = FALSE
 
 /obj/item/radio/ms13/ham/Initialize(mapload, ndir, building)
 	. = ..()
@@ -64,7 +64,7 @@
 	freerange = TRUE
 	anonymize = TRUE
 	anchored = TRUE
-	radio_broadcast = 2
+	radio_broadcast = RADIOSTATIC_MEDIUM
 
 /obj/item/radio/ms13/ham/broadcast/examine(mob/user)
 	. = ..()
@@ -80,7 +80,7 @@
 	freerange = TRUE
 	anonymize = TRUE
 	anchored = TRUE
-	radio_broadcast = 3
+	radio_broadcast = RADIOSATTIC_LIGHT
 /**
  * Override attack_tk_grab instead of attack_tk because we actually want attack_tk's
  * functionality. What we DON'T want is attack_tk_grab attempting to pick up the

--- a/mojave/items/storage/radiopack.dm
+++ b/mojave/items/storage/radiopack.dm
@@ -93,7 +93,7 @@
 	canhear_range = 3
 	freerange = TRUE
 	w_class = WEIGHT_CLASS_SMALL
-	radio_broadcast = 2
+	radio_broadcast = RADIOSTATIC_MEDIUM
 	var/req_radio = TRUE
 	var/obj/item/ms13/storage/backpack/radiopack/radiopack
 

--- a/mojave/items/storage/radiopack.dm
+++ b/mojave/items/storage/radiopack.dm
@@ -78,44 +78,24 @@
 	held = 0
 	if(user)
 		to_chat(user, "<span class='notice'>You attach the [radio.name] to the [name].</span>")
-	else
-		src.visible_message("<span class='warning'>The [radio.name] snaps back onto the [name]!</span>")
 	update_icon()
 	user.update_inv_back()
 
-/obj/item/radio/ms13
-	icon = 'mojave/icons/objects/hamradio.dmi'
-	name = "walkie-talkie"
-	icon_state = "handradio"
-	inhand_icon_state = "handradio_"
-	desc = "A basic handheld radio that communicates over a relatively long range, and is proven to be 254% better than yelling loudly."
-	dog_fashion = /datum/dog_fashion/back
-
-	flags_1 = CONDUCT_1 | HEAR_1
-	throw_speed = 3
-	throw_range = 7
-	w_class = WEIGHT_CLASS_SMALL
-	custom_materials = list(/datum/material/iron=75, /datum/material/glass=25)
-	obj_flags = USES_TGUI
 
 /obj/item/radio/ms13/NCR
-	obj_flags = USES_TGUI
-	broadcasting = TRUE
-	freerange = TRUE
-	frequency = 1359
-	keyslot = new /obj/item/encryptionkey/headset_sec
-	subspace_transmission = TRUE
-	var/obj/item/ms13/storage/backpack/radiopack/radiopack
-	var/req_radio = TRUE
+	icon = 'mojave/icons/objects/hamradio.dmi'
+	name = "Walkie-Talkie"
+	icon_state = "handradio"
+	inhand_icon_state = "handradio_"
+	desc = "The important bit of the radiopack, this broadcasts and recieves radio messages in decent quality."
 
-/obj/item/radio/can_receive(freq, level, AIuser)
-	if(ishuman(src.loc))
-		var/mob/living/carbon/human/H = src.loc
-		if(H.is_holding(src))
-			return ..(freq, level)
-	else if(AIuser)
-		return ..(freq, level)
-	return FALSE
+	flags_1 = CONDUCT_1 | HEAR_1
+	canhear_range = 3
+	freerange = TRUE
+	w_class = WEIGHT_CLASS_SMALL
+	radio_broadcast = 2
+	var/req_radio = TRUE
+	var/obj/item/ms13/storage/backpack/radiopack/radiopack
 
 /obj/item/radio/ms13/NCR/Initialize()
 	if(istype(loc, /obj/item/ms13/storage/backpack/radiopack))
@@ -126,16 +106,12 @@
 
 	return ..()
 
-/obj/item/radio/ms13/NCR/attack_self(mob/living/user)
-	return
 
 /obj/item/radio/ms13/NCR/dropped(mob/user)
 	. = ..()
 	if(user)
 		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	if(req_radio)
-		if(user)
-			to_chat(user, "<span class='notice'>The walkie talkie snaps back into place on the radiopack.</span>")
 		snap_back()
 
 /obj/item/radio/ms13/NCR/proc/snap_back()
@@ -143,9 +119,3 @@
 		return
 	forceMove(radiopack)
 
-/obj/item/radio/ms13/NCR/doMove(atom/destination)
-	if(destination && (destination != radiopack.loc || !ismob(destination)))
-		if (loc != radiopack)
-			to_chat(radiopack.loc, "<span class='notice'>The walkie talkie snaps back into place on the radiopack.</span>")
-		destination = radiopack
-	..()


### PR DESCRIPTION
EDIT: Updated
Reworks radios. Most radios can no longer broadcast, with new radios being added in tiers depending on broadcast quality. Low tier radios have poor broadcast quality and will have significant interference. 

There are four tiers of radio. with tier 1 radios being unable to broadcast. Broadcast radios must be found looting or are spawned with specific roles. 
1st tier: unable to broadcast but can receive just fine, both handheld and ham should be craftable once we get slapcrafting working.
2nd tier: A crappy broadcasting handheld radio. Each character has a 14% chance of being replaced by a *. Should still be a relatively rare spawn.
3rd tier:  A broadcast ham radio, backpack radio, or a very rare pre-war handheld radio. 7% chance of a character being replaced by a *. Handheld should be an extremely rare spawn.
4th tier: A stationary high power broadcast set, usable only from a radio station. 1% chance of a character being replaced by a *.

Loot spawns will still need to be set after this, and we'll need unique sprites for the tiers of radio

The long term goals are to make it so that while receiving radios are very common, broadcasting radios are rare, and people will actually listen to talk shows or news broadcasts due to the rarity of radio broadcasts.

Updates since the beginning of the PR are the removal of crafting recipes and plans for a craftable broadcast radio.