### PR TITLE
Sticky power armor

### DIFF
--- a/mojave/code/modules/clothing/spacesuits/power_armor.dm
+++ b/mojave/code/modules/clothing/spacesuits/power_armor.dm
@@ -19,6 +19,7 @@
 /obj/item/clothing/head/helmet/space/hardsuit/power_armor/Initialize()
 	. = ..()
 	interaction_flags_item &= ~INTERACT_ITEM_ATTACK_HAND_PICKUP
+	ADD_TRAIT(src, TRAIT_NODROP, STICKY_NODROP) //Somehow it's stuck to your body, no questioning.
 
 //Generic power armor based off of the hardsuit
 /obj/item/clothing/suit/space/hardsuit/power_armor
@@ -43,6 +44,7 @@
 /obj/item/clothing/suit/space/hardsuit/power_armor/Initialize()
 	. = ..()
 	interaction_flags_item &= ~INTERACT_ITEM_ATTACK_HAND_PICKUP
+	ADD_TRAIT(src, TRAIT_NODROP, STICKY_NODROP) //Somehow it's stuck to your body, no questioning.
 
 //It's a suit of armor, it ain't going to fall over just because the pilot is dead
 /obj/item/clothing/suit/space/hardsuit/power_armor/equipped(mob/user, slot)
@@ -82,6 +84,8 @@
 			if(do_after(user, 6 SECONDS, target = user) && user.wear_suit == src)
 				GetOutside(user)
 				return TRUE
+			else
+				return FALSE
 
 	to_chat(user, "You begin entering the [src].")
 	if(do_after(user, 6 SECONDS, target = user) && user.wear_suit != src)


### PR DESCRIPTION
<!-- HEY LISTEN!!! -->

<!-- Changelogs will not be used for now.  We will likely require changelogs when we launch. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Apparently you could click drag power armor while having it equipped, this should prevent that and other cases of trying to mishandle the PA
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unequipping PA this way while equipped is bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
