### PR TITLE
Fixes the single metal table icon randomization

### DIFF
--- a/mojave/structures/table.dm
+++ b/mojave/structures/table.dm
@@ -132,7 +132,7 @@
 /obj/structure/table/ms13/no_smooth/metal/Initialize(mapload)
 	. = ..()
 	if(prob(35))
-		icon_state = "(initial[icon_state]-[rand(1,2)]"
+		icon_state = "[initial(icon_state)]-[rand(1,2)]"
 
 // Large tables //
 


### PR DESCRIPTION
As the title says, fixes it. It was scuffed before, now it's not.  Observe all three variations of table: 
![image](https://user-images.githubusercontent.com/51188571/127755292-936e0af6-47fb-497a-abf9-7779d824d302.png)
